### PR TITLE
Escape metadata when generating HTML for epub

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -396,7 +396,7 @@ DOCUMENT_POINTER_TEMPLATE = """\
         itemtype="http://schema.org/Book"
         >
 
-    <title>{{ metadata['title'] }}</title>
+    <title>{{ metadata['title']|escape }}</title>
 
     {# TODO Include this based on the feature being present #}
     <!-- These are for discoverability of accessible content. -->
@@ -417,8 +417,8 @@ DOCUMENT_POINTER_TEMPLATE = """\
         itemtype="http://schema.org/Book"
         >
     <div data-type="metadata">
-      <h1 data-type="document-title" itemprop="name">{{ metadata['title'] \
-                                                     }}</h1>
+      <h1 data-type="document-title" itemprop="name">{{ \
+              metadata['title']|escape }}</h1>
       <span data-type="document" data-value="pointer" />
       {% if metadata.get('cnx-archive-uri') %}
       <span data-type="cnx-archive-uri" data-value="{{ \
@@ -429,7 +429,7 @@ DOCUMENT_POINTER_TEMPLATE = """\
     <div>
       <p>
         Click <a href="{{ metadata['url'] }}">here</a> to read {{ \
-            metadata['title'] }}.
+            metadata['title']|escape }}.
       </p>
     </div>
   </body>
@@ -447,7 +447,7 @@ HTML_DOCUMENT = """\
         itemtype="http://schema.org/Book"
         >
 
-    <title>{{ metadata['title'] }}</title>
+    <title>{{ metadata['title']|escape }}</title>
     <meta itemprop="inLanguage"
           data-type="language"
           content="{{ metadata['language'] }}"
@@ -478,8 +478,8 @@ HTML_DOCUMENT = """\
         itemtype="http://schema.org/Book"
         >
     <div data-type="metadata">
-      <h1 data-type="document-title" itemprop="name">{{ metadata['title'] \
-                                                     }}</h1>
+      <h1 data-type="document-title" itemprop="name">{{ \
+              metadata['title']|escape }}</h1>
       {% if is_translucent %}
       <span data-type="binding" data-value="translucent" />
       {%- endif %}
@@ -610,7 +610,7 @@ HTML_DOCUMENT = """\
         <a href="{{ metadata['derived_from_uri'] }}"
            itemprop="isDerivedFromURL"
            data-type="derived-from"
-           >{{ metadata['derived_from_title'] }}</a>
+           >{{ metadata['derived_from_title']|escape }}</a>
       </div>
       {%- endif %}
 
@@ -668,10 +668,10 @@ HTML_DOCUMENT = """\
       </div>
 
       {% for keyword in metadata['keywords'] -%}
-      <div itemprop="keywords" data-type="keyword">{{ keyword }}</div>
+      <div itemprop="keywords" data-type="keyword">{{ keyword|escape }}</div>
       {%- endfor %}
       {% for subject in metadata['subjects'] -%}
-      <div itemprop="about" data-type="subject">{{ subject }}</div>
+      <div itemprop="about" data-type="subject">{{ subject|escape }}</div>
       {%- endfor %}
 
       <div data-type="resources" style="display: none">

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -399,7 +399,9 @@ class ModelsToEPUBTestCase(unittest.TestCase):
             'illustrators': [],
             'subjects': ['Science and Mathematics'],
             'translators': [],
-            'keywords': ['Bob', 'Sponge', 'Rock'],
+            'keywords': ['Bob', 'Sponge', 'Rock',
+                         # Invalid xml in keywords
+                         '</emphasis>horizontal line'],
             'title': "Goofy Goober Rock",
             'license_text': 'CC-By 4.0',
             'license_url': 'http://creativecommons.org/licenses/by/4.0/',
@@ -491,6 +493,10 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertEqual(len(epub), 1)
         binder = adapt_package(epub[0])
         self.assertEqual(len(list(flatten_model(binder))), 3)
+
+        document = binder[0]
+        self.assertEqual(document.metadata['keywords'],
+                         base_metadata['keywords'])
 
     def test_binder(self):
         """Create an EPUB from a binder with a few documents."""


### PR DESCRIPTION
For example in
https://archive.cnx.org/contents/792137bd-4949-4250-b424-831863286a93@3.json

we have invalid xml in the keywords:

```
"keywords": ["interpolation", "extrapolation", "slope",
"slope-intercept form", "point-slope form", "correlation coefficient",
"<emphasis effect=\"italics\">x</emphasis>-",
"<emphasis effect=\"italics\">y</emphasis>-intercept",
"decreasing function", "increasing function", "least squares regression",
"linear function", "model breakdown", "parallel lines", "perpendicular lines",
"vertical line", "</emphasis>horizontal line",
"intercept<emphasis effect=\"italics\">"]
```