### PR TITLE
Fix tests because `mimetypes.guess_extension` returns ".xht" sometimes

### DIFF
--- a/cnxepub/tests/scripts/test_single_html.py
+++ b/cnxepub/tests/scripts/test_single_html.py
@@ -6,9 +6,14 @@
 # See LICENCE.txt for details.
 # ###
 
+import mimetypes
 import os.path
 import tempfile
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from lxml import etree
 
@@ -16,6 +21,14 @@ from ...html_parsers import HTML_DOCUMENT_NAMESPACES
 from ...testing import TEST_DATA_DIR, captured_output
 
 
+def mocked_guess_extension(*args, **kwargs):
+    # Fix what extension is returned by mimetypes.guess_extension
+    # for the test
+    exts = mimetypes.guess_all_extensions(*args, **kwargs)
+    return sorted(exts)[-1]
+
+
+@mock.patch('mimetypes.guess_extension', mocked_guess_extension)
 class SingleHTMLTestCase(unittest.TestCase):
     @property
     def target(self):
@@ -24,7 +37,7 @@ class SingleHTMLTestCase(unittest.TestCase):
 
     epub_path = os.path.join(TEST_DATA_DIR, 'book')
 
-    maxDiff = 30000
+    maxDiff = None
 
     def xpath(self, path):
         return self.root.xpath(path, namespaces=HTML_DOCUMENT_NAMESPACES)

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -824,15 +824,18 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li')
         self.assertEqual(3, len(lis))
-        self.assertEqual('ingress@draft.xhtml', lis[0][0].attrib['href'])
+        self.assertIn(lis[0][0].attrib['href'],
+                      ['ingress@draft.xhtml', 'ingress@draft.xht'])
         self.assertEqual(u'entrée', lis[0][0].text)
         self.assertEqual('Kranken', lis[1][0].text)
-        self.assertEqual('pointer@1.xhtml', lis[2][0].attrib['href'])
+        self.assertIn(lis[2][0].attrib['href'],
+                      ['pointer@1.xhtml', 'pointer@1.xht'])
         self.assertEqual('Pointer', lis[2][0].text)
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li[2]/xhtml:ol/xhtml:li')
         self.assertEqual(1, len(lis))
-        self.assertEqual('egress@draft.xhtml', lis[0][0].attrib['href'])
+        self.assertIn(lis[0][0].attrib['href'],
+                      ['egress@draft.xhtml', 'egress@draft.xht'])
         self.assertEqual('egress', lis[0][0].text)
 
     def test_translucent_binder(self):
@@ -863,5 +866,6 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li')
         self.assertEqual(1, len(lis))
-        self.assertEqual('ingress@draft.xhtml', lis[0][0].attrib['href'])
+        self.assertIn(lis[0][0].attrib['href'],
+                      ['ingress@draft.xhtml', 'ingress@draft.xht'])
         self.assertEqual(u'entrée', lis[0][0].text)


### PR DESCRIPTION
I'm fixing the tests in this PR but using `mimetypes.guess_extension` might be a problem:

```
>>> import mimetypes
>>> mimetypes.guess_all_extensions('image/jpeg')
['.jpe', '.jpg', '.jpeg']
>>> sorted(mimetypes.guess_all_extensions('image/png'))
['.png']
>>> sorted(mimetypes.guess_all_extensions('text/plain'))
['.asc', '.bat', '.brf', '.c', '.h', '.ksh', '.pl', '.pot', '.srt', '.text', '.txt']
>>> sorted(mimetypes.guess_all_extensions('text/html'))
['.htm', '.html', '.shtml']
>>> mimetypes.guess_all_extensions('application/xhtml+xml')
['.xhtml', '.xht']
```