### PR TITLE
Fix the import for the optional collation feature

### DIFF
--- a/cnxepub/__init__.py
+++ b/cnxepub/__init__.py
@@ -9,4 +9,3 @@ from .epub import *
 from .formatters import *
 from .models import *
 from .adapters import *
-from .collation import *

--- a/cnxepub/collation.py
+++ b/cnxepub/collation.py
@@ -7,17 +7,18 @@
 # ###
 from __future__ import print_function
 import io
-import sys
+import warnings
 
 from lxml import etree
 try:
     from cnxeasybake import Oven
 except ImportError:
-    print("ERROR Missing the cnx-easybake package\n"
-          "HINT Make sure you install the 'collation' extra requirements "
-          "by doing something like `pip install cnx-epub[collation]`.",
-          file=sys.stderr)
-    sys.exit(1)
+    warnings.warn("Missing the cnx-easybake package\n"
+                  "HINT Make sure you install the 'collation' extra "
+                  "requirements by doing something "
+                  "like `pip install cnx-epub[collation]`.",
+                  ImportWarning)
+    raise
 
 from .adapters import adapt_single_html
 from .formatters import SingleHTMLFormatter

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -152,7 +152,7 @@ class CollateTestCase(BaseModelTestCase):
 
     @property
     def target(self):
-        from cnxepub import collate
+        from cnxepub.collation import collate
         return collate
 
     def test(self):


### PR DESCRIPTION
This removes the package level import of collation,
which triggers an ImportError if cnx-easybake is not installed,
which in the case of cnx-archive it won't be.