### PR TITLE
Use null id for new content

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -350,7 +350,7 @@ def _adapt_single_html_tree(parent, elem):
             parent.append(tbinder)
         elif child.attrib.get('data-type') in ['page', 'composite-page']:
             metadata = parse_metadata(child)
-            id_ = metadata['cnx-archive-uri'] or metadata['title']
+            id_ = metadata.get('cnx-archive-uri', None)
             contents = b''.join([
                 etree.tostring(i)
                 for i in child.getchildren()

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -686,11 +686,11 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                     'title': 'Fruity',
                     'contents': [
                         {
-                            'id': 'Apple',
+                            'id': None,
                             'title': 'Apple',
                             },
                         {
-                            'id': 'Lemon',
+                            'id': None,
                             'title': 'Lemon',
                             },
                         {
@@ -698,7 +698,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                             'title': 'Citrus',
                             'contents': [
                                 {
-                                    'id': 'Lemon',
+                                    'id': None,
                                     'title': 'Lemon',
                                     },
                                 ],
@@ -706,11 +706,11 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                         ],
                     },
                 {
-                    'id': u'チョコレート',
+                    'id': None,
                     'title': u'チョコレート',
                     },
                 {
-                    'id': 'Extra Stuff',
+                    'id': None,
                     'title': 'Extra Stuff',
                     },
                 ],

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -21,6 +21,7 @@ TEST_DATA_DIR = os.path.join(here, 'data')
 
 
 class ReconstituteTestCase(unittest.TestCase):
+    maxDiff = None
 
     def test(self):
         from lxml import etree
@@ -42,11 +43,11 @@ class ReconstituteTestCase(unittest.TestCase):
                     'title': 'Fruity',
                     'contents': [
                         {
-                            'id': 'Apple',
+                            'id': None,
                             'title': 'Apple',
                             },
                         {
-                            'id': 'Lemon',
+                            'id': None,
                             'title': 'Lemon',
                             },
                         {
@@ -54,7 +55,7 @@ class ReconstituteTestCase(unittest.TestCase):
                             'title': 'Citrus',
                             'contents': [
                                 {
-                                    'id': 'Lemon',
+                                    'id': None,
                                     'title': 'Lemon',
                                     },
                                 ],
@@ -62,11 +63,11 @@ class ReconstituteTestCase(unittest.TestCase):
                         ],
                     },
                 {
-                    'id': u'チョコレート',
+                    'id': None,
                     'title': u'チョコレート',
                     },
                 {
-                    'id': 'Extra Stuff',
+                    'id': None,
                     'title': 'Extra Stuff',
                     },
                 ],
@@ -220,6 +221,7 @@ class CollateTestCase(BaseModelTestCase):
 
         # Check for the appended composite document
         self.assertEqual(len(collated_binder), 3)
+        self.assertEqual(collated_binder[2].id, None)
         self.assertEqual(collated_binder[2].metadata['title'],
                          'Composite One')
 


### PR DESCRIPTION
The use of the null identifier is the flag that it is new content.