### PR TITLE
Html in titles

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -328,7 +328,7 @@ def adapt_single_html(html):
     metadata = parse_metadata(html_root.xpath('//*[@data-type="metadata"]')[0])
     id_ = metadata['cnx-archive-uri'] or 'book'
 
-    binder = Binder(metadata['cnx-archive-uri'] or 'book', metadata=metadata)
+    binder = Binder(id_, metadata=metadata)
     nav_tree = parse_navigation_html_to_tree(html_root, id_)
     title_overrides = [i.get('title') for i in nav_tree['contents']]
 

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -16,6 +16,15 @@ HTML_DOCUMENT_NAMESPACES = {
     }
 
 
+def _squash_to_text(elm):
+    value = [elm.text or '']
+    for child in elm.getchildren():
+        value.append(etree.tostring(child).decode('utf-8'))
+        value.append(child.tail or '')
+    value = ''.join(value).encode('utf-8')
+    return value
+
+
 def parse_navigation_html_to_tree(html, id):
     """Parse the given ``html`` (an etree object) to a tree.
     The ``id`` is required in order to assign the top-level tree id value.
@@ -135,11 +144,7 @@ class DocumentMetadataParser:
         items = self.parse('.//xhtml:*[@data-type="description"]')
         try:
             description = items[0]
-            value = [description.text]
-            for child in description.getchildren():
-                value.append(etree.tostring(child).decode('utf-8'))
-                value.append(child.tail)
-            value = ''.join(value).encode('utf-8')
+            value = _squash_to_text(description)
         except IndexError:
             value = None
         return value

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -59,7 +59,8 @@ def _nav_to_tree(root):
         if is_subtree:
             # It's a sub-tree and have a 'span' and 'ol'.
             yield {'id': 'subcol',  # Special id...
-                   'title': expath(li, 'xhtml:span/text()')[0],
+                   # Title is wrapped in a span, div or some other element...
+                   'title': expath(li, 'xhtml:*/text()')[0],
                    'contents': [x for x in _nav_to_tree(li)],
                    }
         else:

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -21,7 +21,7 @@ def _squash_to_text(elm):
     for child in elm.getchildren():
         value.append(etree.tostring(child).decode('utf-8'))
         value.append(child.tail or '')
-    value = ''.join(value).encode('utf-8')
+    value = ''.join(value)
     return value
 
 
@@ -66,7 +66,7 @@ def _nav_to_tree(root):
         else:
             # It's a node and should only have an li.
             a = li.xpath('xhtml:a', namespaces=HTML_DOCUMENT_NAMESPACES)[0]
-            yield {'id': a.get('href'), 'title': a.text}
+            yield {'id': a.get('href'), 'title': _squash_to_text(a)}
     raise StopIteration()
 
 
@@ -145,7 +145,7 @@ class DocumentMetadataParser:
         items = self.parse('.//xhtml:*[@data-type="description"]')
         try:
             description = items[0]
-            value = _squash_to_text(description)
+            value = _squash_to_text(description).encode('utf-8')
         except IndexError:
             value = None
         return value


### PR DESCRIPTION
This is logic to fix @helenemccarron's issue on cte-dev. The titles within her nav tree contain an outer wrapping div as well as inner html. At this time we are going to allow the outer wrapping div tag, but it will be removed in the future.