### PR TITLE
detect and pass through attributes on root-of-document nodes

### DIFF
--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -73,7 +73,6 @@ def _nav_to_tree(root):
             a = li.xpath('xhtml:a', namespaces=HTML_DOCUMENT_NAMESPACES)[0]
             yield {'id': a.get('href'),
                    'title': _squash_to_text(a, remove_namespaces=True)}
-    raise StopIteration()
 
 
 def parse_metadata(html):

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -87,7 +87,7 @@
 <h1 data-type="document-title">Part One</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter One</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
+<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
@@ -156,28 +156,17 @@
 
     </div>
 
-   <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
-    
-    
-
    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    
-
-   
-    
-    
-
-   
-    
-    
-
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">If you finish the book, there will be cake.</p>
+  
+  
   </div>
 </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Two</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
+<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
@@ -246,23 +235,12 @@
 
     </div>
 
-   <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
-    
-    
-
    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    
-
-   
-    
-    
-
-   
-    
-    
-
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
+  
+  
   </div>
 </div>
 </div>
@@ -270,7 +248,7 @@
 <h1 data-type="document-title">Part Two</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Three</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
+<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
@@ -339,23 +317,12 @@
 
     </div>
 
-   <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
-    
-    
-
    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    
-
-   
-    
-    
-
-   
-    
-    
-
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">If you finish the book, there will be cake.</p>
+  
+  
   </div>
 </div>
 </div></body>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -87,7 +87,7 @@
 <h1 data-type="document-title">Part One</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter One</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
+<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
@@ -156,28 +156,17 @@
 
     </div>
 
-   <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
-    
-    
-
    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    
-
-   
-    
-    
-
-   
-    
-    
-
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">If you finish the book, there will be cake.</p>
+  
+  
   </div>
 </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Two</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
+<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
@@ -246,23 +235,12 @@
 
     </div>
 
-   <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
-    
-    
-
    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    
-
-   
-    
-    
-
-   
-    
-    
-
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
+  
+  
   </div>
 </div>
 </div>
@@ -270,7 +248,7 @@
 <h1 data-type="document-title">Part Two</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Three</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
+<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
@@ -339,23 +317,12 @@
 
     </div>
 
-   <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
-    
-    
-
    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    
-
-   
-    
-    
-
-   
-    
-    
-
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">If you finish the book, there will be cake.</p>
+  
+  
   </div>
 </div>
 </div></body>

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -41,6 +41,7 @@
         xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute"
         itemscope="itemscope"
         itemtype="http://schema.org/Book"
+        class="fruity"
         >
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     <div data-type="metadata">

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -97,11 +97,7 @@
 
    <h1>Apple Desserts</h1>
 
-
-
 <p id="auto_apple_13436">Here are some examples:</p>
-
-
 
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>
@@ -110,7 +106,7 @@
     <li>Apple sauce...</li>
 </ul>
   </div>
-<div data-type="page" id="lemon">
+<div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -151,23 +147,22 @@
       </div>
     </div>
 
-   <h1>Lemon Desserts</h1>
-
-
+   
+<h1>Lemon Desserts</h1>
 
 <p id="auto_lemon_84744">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_76378"></img></p>
 
-
-
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
     <li>Lemon Cheesecake,</li>
     <li>Raspberry &amp; Lemon Polenta Cake...</li>
 </ul>
+
+
   </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Citrus</h1>
-<div data-type="page" id="lemon">
+<div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -208,19 +203,18 @@
       </div>
     </div>
 
-   <h1>Lemon Desserts</h1>
-
-
+   
+<h1>Lemon Desserts</h1>
 
 <p id="auto_lemon_25507">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_49544"></img></p>
-
-
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
     <li>Lemon Cheesecake,</li>
     <li>Raspberry &amp; Lemon Polenta Cake...</li>
 </ul>
+
+
   </div>
 </div>
 </div>
@@ -267,11 +261,7 @@
 
    <h1>Chocolate Desserts</h1>
 
-
-
 <p id="auto_chocolate_44949"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
-
-
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
@@ -319,11 +309,7 @@
 
    <h1>Extra Stuff</h1>
 
-
-
 <p id="auto_extra_9386">This is a composite page.</p>
-
-
 
 <p id="auto_extra_2834">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
   </div></body>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -97,11 +97,7 @@
 
    <h1>Apple Desserts</h1>
 
-
-
 <p id="auto_apple_17611">Here are some examples:</p>
-
-
 
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>
@@ -110,7 +106,7 @@
     <li>Apple sauce...</li>
 </ul>
   </div>
-<div data-type="page" id="lemon">
+<div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -151,23 +147,22 @@
       </div>
     </div>
 
-   <h1>Lemon Desserts</h1>
-
-
+   
+<h1>Lemon Desserts</h1>
 
 <p id="auto_lemon_74606">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_8271"></img></p>
 
-
-
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
     <li>Lemon Cheesecake,</li>
     <li>Raspberry &amp; Lemon Polenta Cake...</li>
 </ul>
+
+
   </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Citrus</h1>
-<div data-type="page" id="lemon">
+<div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -208,19 +203,18 @@
       </div>
     </div>
 
-   <h1>Lemon Desserts</h1>
-
-
+   
+<h1>Lemon Desserts</h1>
 
 <p id="auto_lemon_33432">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_15455"></img></p>
-
-
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
     <li>Lemon Cheesecake,</li>
     <li>Raspberry &amp; Lemon Polenta Cake...</li>
 </ul>
+
+
   </div>
 </div>
 </div>
@@ -267,11 +261,7 @@
 
    <h1>Chocolate Desserts</h1>
 
-
-
 <p id="auto_chocolate_64937"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
-
-
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
@@ -319,11 +309,7 @@
 
    <h1>Extra Stuff</h1>
 
-
-
 <p id="auto_extra_61898">This is a composite page.</p>
-
-
 
 <p id="auto_extra_85405">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
   </div></body>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -300,16 +300,16 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         expected_content = """\
 <div class="title" id="auto_{id}_title">Preface</div>
-\n\n
+
 <p class="para" id="auto_{id}_my-id">This thing and <em>that</em> thing.</p>
-\n\n
+
 <p class="para" id="auto_{id}_{n}"><a href="#auto_{id}_title">Link</a> to title</p>\
 """.format(id=page_one_id, n=random.randint(0, 100000))
 
         random.seed(1)
         document = Document(page_one_id, content)
-        self.assertIn(expected_content,
-                      str(HTMLFormatter(document, generate_ids=True)))
+        formatted = str(HTMLFormatter(document, generate_ids=True))
+        self.assertIn(expected_content, formatted)
 
 
 @mock.patch('mimetypes.guess_extension', last_extension)
@@ -375,6 +375,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Lemon'
         contents = io.BytesIO(b"""\
+<body class="fruity">
 <h1>Lemon Desserts</h1>
 <p>Yum! <img src="/resources/1x1.jpg" /></p>
 <ul><li>Lemon &amp; Lime Crush,</li>
@@ -382,6 +383,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
     <li>Lemon Cheesecake,</li>
     <li>Raspberry &amp; Lemon Polenta Cake...</li>
 </ul>
+</body>
 """)
         self.lemon = Document('lemon', contents, metadata=metadata,
                               resources=[jpg])
@@ -430,8 +432,8 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         with open(page_path, 'r') as f:
             expected_content = f.read()
 
-        self.assertMultiLineEqual(
-            expected_content, str(SingleHTMLFormatter(self.desserts)))
+        actual = str(SingleHTMLFormatter(self.desserts))
+        self.assertMultiLineEqual(expected_content, actual)
 
     def test_str_unicode_bytes(self):
         import random


### PR DESCRIPTION
Fairly invasive, hacky approach to passing through any attributes that are set on the root of the document node. Considering how often we're wrapping and unwrapping the Document tree, I think we may actually have a wrong model for Document.content: right now it's a HTML fragment,  I think we should just bite the bullet and refactor this, eventually. For now, I've added special case code to grab any non-template-added attributes (not itemscope/itemtype) and pass them onto each new root as it's created.