### PR TITLE
fix my breakage of id-adding xpaths and tests

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -95,7 +95,7 @@ class HTMLFormatter(object):
             'blockquote', 'q', 'code', 'pre', 'object', 'img', 'audio',
             'video',
             ]
-        elements_xpath = '|'.join(['//{}|//xhtml:{}'.format(elem, elem)
+        elements_xpath = '|'.join(['.//{}|.//xhtml:{}'.format(elem, elem)
                                   for elem in elements])
 
         data_types = [
@@ -103,7 +103,7 @@ class HTMLFormatter(object):
             'footnote-number', 'footnote-ref', 'problem', 'solution', 'media',
             'proof', 'statement', 'commentary'
             ]
-        data_types_xpath = '|'.join(['//*[@data-type="{}"]'.format(data_type)
+        data_types_xpath = '|'.join(['.//*[@data-type="{}"]'.format(data_type)
                                      for data_type in data_types])
 
         xpath = '|'.join([elements_xpath, data_types_xpath])

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -159,7 +159,7 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -238,7 +238,7 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_25507">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -320,7 +320,7 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_44949">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">If you finish the book, there will be cake.</p>
   
   
   </div>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -159,7 +159,7 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -238,7 +238,7 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_33432">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -320,7 +320,7 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_64937">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">If you finish the book, there will be cake.</p>
   
   
   </div>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -97,7 +97,7 @@
 
    <h1>Apple Desserts</h1>
 
-<p id="auto_apple_84744">Here are some examples:</p>
+<p id="auto_apple_13436">Here are some examples:</p>
 
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>
@@ -150,7 +150,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_25507">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_49544"></img></p>
+<p id="auto_lemon_84744">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_76378"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -206,7 +206,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_65159">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_78873"></img></p>
+<p id="auto_lemon_25507">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_49544"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -261,13 +261,13 @@
 
    <h1>Chocolate Desserts</h1>
 
-<p id="auto_chocolate_2834"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
+<p id="auto_chocolate_44949"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_83577"></img><p id="auto_chocolate_43277">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_65159"></img><p id="auto_chocolate_78873">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
   </div>
 <div data-type="composite-page" id="extra">
 <div data-type="metadata">
@@ -309,8 +309,8 @@
 
    <h1>Extra Stuff</h1>
 
-<p id="auto_extra_210">This is a composite page.</p>
+<p id="auto_extra_9386">This is a composite page.</p>
 
-<p id="auto_extra_44539">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+<p id="auto_extra_2834">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
   </div></body>
 </html>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -97,7 +97,7 @@
 
    <h1>Apple Desserts</h1>
 
-<p id="auto_apple_74606">Here are some examples:</p>
+<p id="auto_apple_17611">Here are some examples:</p>
 
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>
@@ -150,7 +150,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_33432">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_15455"></img></p>
+<p id="auto_lemon_74606">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_8271"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -206,7 +206,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_99740">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_58915"></img></p>
+<p id="auto_lemon_33432">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_15455"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -261,13 +261,13 @@
 
    <h1>Chocolate Desserts</h1>
 
-<p id="auto_chocolate_85405"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
+<p id="auto_chocolate_64937"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_49756"></img><p id="auto_chocolate_27519">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_99740"></img><p id="auto_chocolate_58915">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
   </div>
 <div data-type="composite-page" id="extra">
 <div data-type="metadata">
@@ -309,8 +309,8 @@
 
    <h1>Extra Stuff</h1>
 
-<p id="auto_extra_63944">This is a composite page.</p>
+<p id="auto_extra_61898">This is a composite page.</p>
 
-<p id="auto_extra_3715">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+<p id="auto_extra_85405">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
   </div></body>
 </html>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -734,7 +734,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, apple_metadata)
-        self.assertIn('>Here are some examples:</p>',
+        self.assertIn('<p id="17611">Here are some examples:</p>',
                       apple.content)
         self.assertEqual('Apple', fruity.get_title_for_node(apple))
 
@@ -747,7 +747,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, lemon_metadata)
-        self.assertIn('>Yum! <img src="/resources/1x1.jpg" ', lemon.content)
+        self.assertIn('<p id="74606">Yum! <img src="/resources/1x1.jpg" '
+                      'id="8271"/></p>', lemon.content)
         self.assertEqual('<span>1.1</span> <span>|</span> <span>'
                          '&#12524;&#12514;&#12531;</span>',
                          fruity.get_title_for_node(lemon))
@@ -770,7 +771,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = u'チョコレート'
         self.assertEqual(metadata, chocolate_metadata)
-        self.assertIn('><a href="#list">List</a> of',
+        self.assertIn('<p id="64937"><a href="#list">List</a> of',
                       chocolate.content)
         self.assertIn('<div data-type="list" id="list"><ul>',
                       chocolate.content)
@@ -786,7 +787,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Extra Stuff'
         self.assertEqual(metadata, extra_metadata)
-        self.assertIn('>Here is a <a href="/contents/chocolate'
+        self.assertIn('<p id="85405">Here is a <a href="/contents/chocolate'
                       '#list">link</a> to another document.</p>',
                       extra.content)
         self.assertEqual('Extra Stuff', desserts.get_title_for_node(extra))

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -292,7 +292,6 @@ class HTMLFormatterTestCase(unittest.TestCase):
         from ..formatters import HTMLFormatter
 
         random.seed(1)
-        n = random.randint(0, 100000)
         content = """\
 <div class="title" id="title">Preface</div>
 <p class="para" id="my-id">This thing and <em>that</em> thing.</p>
@@ -434,8 +433,6 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             expected_content = f.read()
 
         actual = str(SingleHTMLFormatter(self.desserts))
-        with open('/tmp/desserts-single-page-py2.xhtml', 'w') as f:
-            f.write(actual)
         self.assertMultiLineEqual(expected_content, actual)
 
     def test_str_unicode_bytes(self):


### PR DESCRIPTION
title say sit all. Making the xpaths global broke ID adding, which broke the tests in interesting ways. This reverts all the test changes, and makes the xapths relative again, while retaining the correct namespace-alternative behavior, that was the original point of the change.