### PR TITLE
local intra-book link rewriting

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -364,6 +364,12 @@ def _adapt_single_html_tree(parent, elem, nav_tree, pages_by_id=None, depth=0):
             else:
                 i.attrib['href'] = '/contents/{}#{}'.format(
                     target_page.id, target)
+        page_id_xpath = ' or '.join([
+            '@href = "#{}"'.format(page_id)
+            for page_id in pages_by_id])
+        for i in content.xpath('.//*[{}]'.format(page_id_xpath)):
+            i.attrib['href'] = '/contents/{}'.format(
+                i.attrib['href'].split('#')[-1])
 
     # A dictionary to allow look up a document using the page id (the id
     # attribute of <div data-type="page|composite-page">)

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -159,7 +159,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+   
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -238,7 +240,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+   
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_25507">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -320,7 +324,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_49544">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+   
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_44949">If you finish the book, there will be cake.</p>
   
   
   </div>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -159,7 +159,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+   
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -238,7 +240,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+   
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_33432">If you finish the book, there will be cake.</p>
   
   
   </div>
@@ -320,7 +324,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">If you finish the book, there will be cake.</p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_15455">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+   
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_64937">If you finish the book, there will be cake.</p>
   
   
   </div>

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -172,6 +172,7 @@
       </div>
     </div>
 
+   <p class="para">Do you understand everything in <a href="/contents/e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    <p class="para" id="">If you finish the book, there will be cake.</p>
   </body>
 </html>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -97,7 +97,7 @@
 
    <h1>Apple Desserts</h1>
 
-<p id="auto_apple_13436">Here are some examples:</p>
+<p id="auto_apple_13436"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>

--- a/cnxepub/tests/data/desserts-single-page.html
+++ b/cnxepub/tests/data/desserts-single-page.html
@@ -99,7 +99,7 @@
 
 
 
-<p id="auto_apple_17611">Here are some examples:</p>
+<p id="auto_apple_17611"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
 
 

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -97,7 +97,7 @@
 
    <h1>Apple Desserts</h1>
 
-<p id="auto_apple_17611">Here are some examples:</p>
+<p id="auto_apple_17611"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -734,7 +734,9 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, apple_metadata)
-        self.assertIn('<p id="17611">Here are some examples:</p>',
+        self.assertIn('<p id="17611">'
+                      '<a href="/contents/lemon">Link to lemon</a>. '
+                      'Here are some examples:</p>',
                       apple.content)
         self.assertEqual('Apple', fruity.get_title_for_node(apple))
 

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -362,7 +362,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         metadata['title'] = 'Apple'
         contents = io.BytesIO(b"""\
 <h1>Apple Desserts</h1>
-<p>Here are some examples:</p>
+<p><a href="/contents/lemon">Link to lemon</a>. Here are some examples:</p>
 <ul><li>Apple Crumble,</li>
     <li>Apfelstrudel,</li>
     <li>Caramel Apple,</li>


### PR DESCRIPTION
This converts links that look like /contents/<page-uuid>[#hash]  that link to other parts of the book, into local fragment links within the single-page html. This allows the target-link rules in the recipes to fill in the appropriate target-label value (including generated text labels and numbers, like Table 4.3)