### PR TITLE
Fix links to elements that were moved to another page after collation

### DIFF
--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -1,0 +1,319 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Desserts</title>
+    <meta itemprop="inLanguage" data-type="language" content=""></meta>
+
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"></meta>
+    <meta itemprop="accessibilityFeature" content="LaTeX"></meta>
+    <meta itemprop="accessibilityFeature" content="alternativeText"></meta>
+    <meta itemprop="accessibilityFeature" content="captions"></meta>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"></meta>
+
+
+    <meta itemprop="dateCreated" content=""></meta>
+    <meta itemprop="dateModified" content=""></meta>
+  </head>
+  <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Desserts</h1>
+
+      <div class="authors">
+        By:
+
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+        </p>
+      </div>
+
+      <div class="description" itemprop="description" data-type="description">
+        
+      </div>
+
+
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="cover.png">cover.png</a></li>        </ul>
+      </div>
+    </div>
+
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+  <div data-type="unit">
+<h1 data-type="document-title">Fruity</h1>
+<div data-type="page" id="apple">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Apple</h1>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" itemprop="description" data-type="description">
+        <p>summary</p>
+      </div>
+
+<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+
+    </div>
+
+   <h1>Apple Desserts</h1>
+
+<p id="auto_apple_17611"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
+
+<ul><li>Apple Crumble,</li>
+    <li>Apfelstrudel,</li>
+    <li>Caramel Apple,</li>
+    <li>Apple Pie,</li>
+    <li>Apple sauce...</li>
+</ul>
+  </div>
+<div data-type="page" id="lemon" class="fruity">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" itemprop="description" data-type="description">
+        <p>summary</p>
+      </div>
+
+<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
+      </div>
+    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_74606">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_8271"></img></p>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div>
+<div data-type="chapter">
+<h1 data-type="document-title">Citrus</h1>
+<div data-type="page" id="lemon" class="fruity">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" itemprop="description" data-type="description">
+        <p>summary</p>
+      </div>
+
+<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
+      </div>
+    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_33432">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_15455"></img></p>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div>
+</div>
+</div>
+<div data-type="page" id="chocolate">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</h1>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" itemprop="description" data-type="description">
+        <p>summary</p>
+      </div>
+
+<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
+      </div>
+    </div>
+
+   <h1>Chocolate Desserts</h1>
+
+<p id="auto_chocolate_64937"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
+
+<div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
+    <li>Hot Mocha Puddings,</li>
+    <li>Chocolate and Banana French Toast,</li>
+    <li>Chocolate Truffles...</li>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_99740"></img><p id="auto_chocolate_58915">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
+<p>Click <a href="#auto_chocolate_1">here</a> to see more notes.</p>
+  </div>
+<div data-type="composite-page" id="extra">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" itemprop="description" data-type="description">
+        <p>summary</p>
+      </div>
+
+<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+
+    </div>
+
+   <h1>Extra Stuff</h1>
+
+<p id="auto_extra_61898">This is a composite page.</p>
+
+<p id="auto_chocolate_1">Content moved from another page.</p>
+
+<p id="auto_extra_85405">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+  </div></body>
+</html>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -806,3 +806,21 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         from ..adapters import AdaptationError
         with self.assertRaises(AdaptationError) as caught_exception:
             desserts = adapt_single_html(html)
+
+    def test_fix_generated_ids_in_composite_page(self):
+        from ..adapters import adapt_single_html
+
+        page_path = os.path.join(TEST_DATA_DIR,
+                                 'collated-desserts-single-page.xhtml')
+        with open(page_path, 'r') as f:
+            html = f.read()
+
+        desserts = adapt_single_html(html)
+
+        chocolate = desserts[1]
+        extra = desserts[2]
+
+        self.assertIn('<p id="1">Content moved from another page.</p>',
+                      extra.content)
+        self.assertIn('Click <a href="/contents/extra#1">here</a>',
+                      chocolate.content)


### PR DESCRIPTION
During reconstitution from single html, if there is a link to an element
that was moved to another page, the code would change the link to an
absolute link to the original page.

For example, the first link in the answer key in Principles of Economics
http://cte-cnx-dev.cnx.org/contents/aWGdK2jw@11.326:RPeQk8jq@1/Answer-Key
was pointing to
http://cte-cnx-dev.cnx.org/contents/aWGdK2jw@11.326:3#fs-idm91372672,
but #fs-idm91372672 is no longer on page 3 of the book after collation.