### PR TITLE
Fix collation links

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -334,8 +334,6 @@ def adapt_single_html(html):
     ``.formatters.SingleHTMLFormatter`` to a ``models.Binder``
     """
     html_root = etree.fromstring(html)
-    # parse_metadata, parse_navigation_html_to_tree,
-    # parse_resources, DocumentPointerMetadataParser
 
     metadata = parse_metadata(html_root.xpath('//*[@data-type="metadata"]')[0])
     id_ = metadata['cnx-archive-uri'] or 'book'
@@ -366,8 +364,11 @@ def _adapt_single_html_tree(parent, elem, nav_tree, pages_by_id=None, depth=0):
                     target_page.id, target)
         target_pages = set(pages_by_id.values())
         if target_pages:
+            page_ids_wo_versions = [
+                page.id.split('@')[0] for page in target_pages]
             page_id_xpath = ' or '.join([
-                '@href = "#{}"'.format(page.id) for page in target_pages])
+                'starts-with(@href, "#{}")'.format(page_id)
+                for page_id in page_ids_wo_versions])
             for i in content.xpath('.//*[{}]'.format(page_id_xpath)):
                 i.attrib['href'] = '/contents/{}'.format(
                     i.attrib['href'].split('#')[-1])

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -105,6 +105,7 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
+<p id="auto_apple_12345"><a href="#chocolate">Link to chocolate</a>.</p>
   </div>
 <div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
@@ -218,7 +219,7 @@
   </div>
 </div>
 </div>
-<div data-type="page" id="chocolate">
+<div data-type="page" id="chocolate@1">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</h1>
 

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -824,3 +824,17 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                       extra.content)
         self.assertIn('Click <a href="/contents/extra#1">here</a>',
                       chocolate.content)
+
+    def test_fix_generated_ids_links_without_version(self):
+        from ..adapters import adapt_single_html
+
+        page_path = os.path.join(TEST_DATA_DIR,
+                                 'collated-desserts-single-page.xhtml')
+
+        with open(page_path, 'r') as f:
+            html = f.read()
+
+        desserts = adapt_single_html(html)
+        apple = desserts[0][0]
+        self.assertIn('<p id="12345"><a href="/contents/chocolate">',
+                      apple.content)


### PR DESCRIPTION
Fix code that converts `#<page-id>` to `/contents/<page-id>`

The specific example is on cte-dev "Introductory Statistics", on page
"Frequency, Frequency Tables, and Levels of Measurement" link to
"Probability Topics" pointing to
"/contents/326ee2e0-0ccd-46ae-a776-f8857a5dad4c@7".

When the binder is changed to a single html, the link is changed to
"#326ee2e0-0ccd-46ae-a776-f8857a5dad4c", but when adapting from single
html back into the binder, the code looks for the page id, that is,
"#326ee2e0-0ccd-46ae-a776-f8857a5dad4c@7".

This change converts both "#326ee2e0-0ccd-46ae-a776-f8857a5dad4c@7" and
"#326ee2e0-0ccd-46ae-a776-f8857a5dad4c".