### PR TITLE
rewrite every href that resolves inside the book

### DIFF
--- a/cnxepub/scripts/collated_single_html/main.py
+++ b/cnxepub/scripts/collated_single_html/main.py
@@ -34,6 +34,9 @@ def main(argv=None):
     parser.add_argument('-d', '--dump-tree', action='store_true',
                         help='Print out parsed model tree.')
 
+    parser.add_argument('-o', '--output', type=argparse.FileType('w'),
+                        help='Write out epub of parsed tree.')
+
     args = parser.parse_args(argv)
 
     from cnxepub.collation import reconstitute
@@ -42,6 +45,9 @@ def main(argv=None):
     if args.dump_tree:
         print(pformat(cnxepub.model_to_tree(binder)),
               file=sys.stdout)
+
+    if args.output:
+        cnxepub.adapters.make_epub(binder, args.output)
 
     # TODO Check for documents that have no identifier.
     #      These should likely be composite-documents

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit">
 <h1 data-type="document-title">Fruity</h1>
 <div data-type="page" id="apple">
@@ -107,60 +107,6 @@
 </ul>
 <p id="auto_apple_12345"><a href="#chocolate">Link to chocolate</a>.</p>
   </div>
-<div data-type="page" id="lemon" class="fruity">
-<div data-type="metadata">
-      <h1 data-type="document-title" itemprop="name">Lemon</h1>
-
-      <div class="authors">
-        By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
-          </span>
-        Edited by:
-
-        Illustrated by:
-
-        Translated by:
-
-      </div>
-
-      <div class="publishers">
-        Published By:
-      </div>
-
-
-
-      <div class="permissions">
-        <p class="license">
-          Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
-        </p>
-      </div>
-
-      <div class="description" itemprop="description" data-type="description">
-        <p>summary</p>
-      </div>
-
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
-      <div data-type="resources" style="display: none">
-        <ul>
-<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
-      </div>
-    </div>
-
-   
-<h1>Lemon Desserts</h1>
-
-<p id="auto_lemon_74606">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_8271"></img></p>
-
-<ul><li>Lemon &amp; Lime Crush,</li>
-    <li>Lemon Drizzle Loaf,</li>
-    <li>Lemon Cheesecake,</li>
-    <li>Raspberry &amp; Lemon Polenta Cake...</li>
-</ul>
-
-
-  </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Citrus</h1>
 <div data-type="page" id="lemon" class="fruity">
@@ -207,7 +153,8 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_33432">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_15455"></img></p>
+<p id="auto_lemon_74606">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_8271"></img></p>
+<p id="myid">Be sure to read the <a href="#auto_lemon_summary">Summary for lemon</a></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -316,5 +263,8 @@
 <p id="auto_chocolate_1">Content moved from another page.</p>
 
 <p id="auto_extra_85405">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+<p id="auto_apple_summary"> Pretend move of apple summary</p>
+<p id="auto_lemon_summary"> Pretend move of lemon summary</p>
+<p id="auto_chocolate_summary"> Pretend move of chocolate summary</p>
   </div></body>
 </html>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -817,6 +817,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
 
         desserts = adapt_single_html(html)
 
+        lemon = desserts[0][1][0]
         chocolate = desserts[1]
         extra = desserts[2]
 
@@ -824,6 +825,11 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                       extra.content)
         self.assertIn('Click <a href="/contents/extra#1">here</a>',
                       chocolate.content)
+        self.assertIn('<p id="summary0"> Pretend move of lemon summary</p>',
+                      extra.content)
+        self.assertIn('<p id="summary1"> Pretend move of chocolate summary</p>',
+                      extra.content)
+        self.assertIn('<p id="myid">Be sure to read the <a href="/contents/extra#summary0">Summary for lemon</a></p>', lemon.content)
 
     def test_fix_generated_ids_links_without_version(self):
         from ..adapters import adapt_single_html


### PR DESCRIPTION
This will allow rulesets to create any `id` they want (as long as it's unique in the whole book) and create `href` links to them. These links will then be rewritten. Also gripes about bad `hrefs` (`#id` w/ no such `id` in the book)