### PR TITLE
Namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.3"
+  - "3.5"
 before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage

--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -57,7 +57,15 @@ XML_WRAPPER = """\
   xmlns:epub="http://www.idpf.org/2007/ops"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:dc="http://purl.org/dc/elements/1.1/"
-  xmlns:lrmi="http://lrmi.net/the-specification">
+  xmlns:lrmi="http://lrmi.net/the-specification"
+  xmlns:math="http://www.w3.org/1998/Math/MathML"
+  xmlns:qml="http://cnx.rice.edu/qml/1.0"
+  xmlns:datadev="http://dev.w3.org/html5/spec/#custom"
+  xmlns:modids="http://cnx.rice.edu/#moduleIds"
+  xmlns:bib="http://bibtexml.sf.net/"
+  xmlns:md="http://cnx.rice.edu/mdml"
+  xmlns:cnxml="http://cnx.rice.edu/cnxml"
+  >
 {}
 </div>"""
 

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -1,51 +1,51 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta itemprop="inLanguage" data-type="language" content="None"></meta>
+    <meta content="None" data-type="language" itemprop="inLanguage"></meta>
 
-    <!-- These are for discoverability of accessible content. -->
-    <meta itemprop="accessibilityFeature" content="MathML"></meta>
-    <meta itemprop="accessibilityFeature" content="LaTeX"></meta>
-    <meta itemprop="accessibilityFeature" content="alternativeText"></meta>
-    <meta itemprop="accessibilityFeature" content="captions"></meta>
-    <meta itemprop="accessibilityFeature" content="structuredNavigation"></meta>
+    
+    <meta content="MathML" itemprop="accessibilityFeature"></meta>
+    <meta content="LaTeX" itemprop="accessibilityFeature"></meta>
+    <meta content="alternativeText" itemprop="accessibilityFeature"></meta>
+    <meta content="captions" itemprop="accessibilityFeature"></meta>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"></meta>
 
 
-    <meta itemprop="dateCreated" content="2013/03/19 15:01:16 -0500"></meta>
-    <meta itemprop="dateModified" content="2013/06/18 15:22:55 -0500"></meta>
+    <meta content="2013/03/19 15:01:16 -0500" itemprop="dateCreated"></meta>
+    <meta content="2013/06/18 15:22:55 -0500" itemprop="dateModified"></meta>
   </head>
-  <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
 
@@ -53,19 +53,19 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="None" itemprop="url" data-type="None">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="None" href="None" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
-        <ul xmlns="http://www.w3.org/1999/xhtml" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification" class="list">
+        <ul class="list">
           <li class="item">Drive a car</li>
           <li class="item">Purchase a watch</li>
           <li class="item">Wear funny hats</li>
@@ -75,7 +75,7 @@
       
       </div>
 
-<div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="subject" itemprop="about">Science and Mathematics</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
@@ -87,42 +87,42 @@
 <h1 data-type="document-title">Part One</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter One</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
+<div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
       <div class="derived-from">
         Derived from:
-        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
+        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -131,16 +131,16 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
         <ul class="list">
@@ -152,12 +152,12 @@
       
       </div>
 
-<div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>
 
     </div>
 
    
-    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
+    
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
    
@@ -168,42 +168,42 @@
 </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Two</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
+<div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
       <div class="derived-from">
         Derived from:
-        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
+        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -212,16 +212,16 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
         <ul class="list">
@@ -233,12 +233,12 @@
       
       </div>
 
-<div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>
 
     </div>
 
    
-    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
+    
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
    
@@ -252,42 +252,42 @@
 <h1 data-type="document-title">Part Two</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Three</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
+<div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
       <div class="derived-from">
         Derived from:
-        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
+        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -296,16 +296,16 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
         <ul class="list">
@@ -317,12 +317,12 @@
       
       </div>
 
-<div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>
 
     </div>
 
    
-    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
+    
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_49544">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
    

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -1,51 +1,51 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta itemprop="inLanguage" data-type="language" content="None"></meta>
+    <meta content="None" data-type="language" itemprop="inLanguage"></meta>
 
-    <!-- These are for discoverability of accessible content. -->
-    <meta itemprop="accessibilityFeature" content="MathML"></meta>
-    <meta itemprop="accessibilityFeature" content="LaTeX"></meta>
-    <meta itemprop="accessibilityFeature" content="alternativeText"></meta>
-    <meta itemprop="accessibilityFeature" content="captions"></meta>
-    <meta itemprop="accessibilityFeature" content="structuredNavigation"></meta>
+    
+    <meta content="MathML" itemprop="accessibilityFeature"></meta>
+    <meta content="LaTeX" itemprop="accessibilityFeature"></meta>
+    <meta content="alternativeText" itemprop="accessibilityFeature"></meta>
+    <meta content="captions" itemprop="accessibilityFeature"></meta>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"></meta>
 
 
-    <meta itemprop="dateCreated" content="2013/03/19 15:01:16 -0500"></meta>
-    <meta itemprop="dateModified" content="2013/06/18 15:22:55 -0500"></meta>
+    <meta content="2013/03/19 15:01:16 -0500" itemprop="dateCreated"></meta>
+    <meta content="2013/06/18 15:22:55 -0500" itemprop="dateModified"></meta>
   </head>
-  <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
 
@@ -53,19 +53,19 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="None" itemprop="url" data-type="None">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="None" href="None" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
-        <ul xmlns="http://www.w3.org/1999/xhtml" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification" class="list">
+        <ul class="list">
           <li class="item">Drive a car</li>
           <li class="item">Purchase a watch</li>
           <li class="item">Wear funny hats</li>
@@ -75,7 +75,7 @@
       
       </div>
 
-<div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="subject" itemprop="about">Science and Mathematics</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
@@ -87,42 +87,42 @@
 <h1 data-type="document-title">Part One</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter One</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
+<div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
       <div class="derived-from">
         Derived from:
-        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
+        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -131,16 +131,16 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
         <ul class="list">
@@ -152,12 +152,12 @@
       
       </div>
 
-<div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>
 
     </div>
 
    
-    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
+    
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
    
@@ -168,42 +168,42 @@
 </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Two</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
+<div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
       <div class="derived-from">
         Derived from:
-        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
+        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -212,16 +212,16 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
         <ul class="list">
@@ -233,12 +233,12 @@
       
       </div>
 
-<div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>
 
     </div>
 
    
-    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
+    
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
    
@@ -252,42 +252,42 @@
 <h1 data-type="document-title">Part Two</h1>
 <div data-type="chapter">
 <h1 data-type="document-title">Chapter Three</h1>
-<div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3" class="fruity">
+<div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"></span>
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
-          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
-          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
+          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
+          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
-              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
+            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
         Translated by:
-            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
-              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
+            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
             </span>
       </div>
 
       <div class="publishers">
         Published By:
-            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
-              <a href="None" itemprop="url" data-type="None">Ream</a>
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="None" href="None" itemprop="url">Ream</a>
             </span>      </div>
 
       <div class="derived-from">
         Derived from:
-        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
+        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -296,16 +296,16 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
-                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
         By the end of this section, you will be able to: 
         <ul class="list">
@@ -317,12 +317,12 @@
       
       </div>
 
-<div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>
+<div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>
 
     </div>
 
    
-    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
+    
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_15455">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
    

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -1,21 +1,21 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta itemprop="inLanguage" data-type="language" content=""></meta>
+    <meta content="" data-type="language" itemprop="inLanguage"></meta>
 
-    <!-- These are for discoverability of accessible content. -->
-    <meta itemprop="accessibilityFeature" content="MathML"></meta>
-    <meta itemprop="accessibilityFeature" content="LaTeX"></meta>
-    <meta itemprop="accessibilityFeature" content="alternativeText"></meta>
-    <meta itemprop="accessibilityFeature" content="captions"></meta>
-    <meta itemprop="accessibilityFeature" content="structuredNavigation"></meta>
+    
+    <meta content="MathML" itemprop="accessibilityFeature"></meta>
+    <meta content="LaTeX" itemprop="accessibilityFeature"></meta>
+    <meta content="alternativeText" itemprop="accessibilityFeature"></meta>
+    <meta content="captions" itemprop="accessibilityFeature"></meta>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"></meta>
 
 
-    <meta itemprop="dateCreated" content=""></meta>
-    <meta itemprop="dateModified" content=""></meta>
+    <meta content="" itemprop="dateCreated"></meta>
+    <meta content="" itemprop="dateModified"></meta>
   </head>
-  <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
 
@@ -39,11 +39,11 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+          <a data-type="license" href="" itemprop="dc:license,lrmi:useRightsURL"></a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
       </div>
 
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit">
 <h1 data-type="document-title">Fruity</h1>
 <div data-type="page" id="apple">
@@ -63,8 +63,8 @@
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -83,15 +83,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
 
     </div>
 
@@ -106,14 +106,14 @@
     <li>Apple sauce...</li>
 </ul>
   </div>
-<div data-type="page" id="lemon" class="fruity">
+<div class="fruity" data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -132,15 +132,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -150,7 +150,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_84744">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_76378"></img></p>
+<p id="auto_lemon_84744">Yum! <img id="auto_lemon_76378" src="/resources/1x1.jpg"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -162,14 +162,14 @@
   </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Citrus</h1>
-<div data-type="page" id="lemon" class="fruity">
+<div class="fruity" data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -188,15 +188,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -206,7 +206,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_25507">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_49544"></img></p>
+<p id="auto_lemon_25507">Yum! <img id="auto_lemon_49544" src="/resources/1x1.jpg"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -220,12 +220,12 @@
 </div>
 <div data-type="page" id="chocolate">
 <div data-type="metadata">
-      <h1 data-type="document-title" itemprop="name">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</h1>
+      <h1 data-type="document-title" itemprop="name">チョコレート</h1>
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -244,15 +244,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -267,7 +267,7 @@
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_65159"></img><p id="auto_chocolate_78873">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
+</ul></div><img id="auto_chocolate_65159" src="/resources/1x1.jpg"></img><p id="auto_chocolate_78873">チョコレートデザート</p>
   </div>
 <div data-type="composite-page" id="extra">
 <div data-type="metadata">
@@ -275,8 +275,8 @@
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -295,15 +295,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
 
     </div>
 

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -1,21 +1,21 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta itemprop="inLanguage" data-type="language" content=""></meta>
+    <meta content="" data-type="language" itemprop="inLanguage"></meta>
 
-    <!-- These are for discoverability of accessible content. -->
-    <meta itemprop="accessibilityFeature" content="MathML"></meta>
-    <meta itemprop="accessibilityFeature" content="LaTeX"></meta>
-    <meta itemprop="accessibilityFeature" content="alternativeText"></meta>
-    <meta itemprop="accessibilityFeature" content="captions"></meta>
-    <meta itemprop="accessibilityFeature" content="structuredNavigation"></meta>
+    
+    <meta content="MathML" itemprop="accessibilityFeature"></meta>
+    <meta content="LaTeX" itemprop="accessibilityFeature"></meta>
+    <meta content="alternativeText" itemprop="accessibilityFeature"></meta>
+    <meta content="captions" itemprop="accessibilityFeature"></meta>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"></meta>
 
 
-    <meta itemprop="dateCreated" content=""></meta>
-    <meta itemprop="dateModified" content=""></meta>
+    <meta content="" itemprop="dateCreated"></meta>
+    <meta content="" itemprop="dateModified"></meta>
   </head>
-  <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
 
@@ -39,11 +39,11 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+          <a data-type="license" href="" itemprop="dc:license,lrmi:useRightsURL"></a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         
       </div>
 
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit">
 <h1 data-type="document-title">Fruity</h1>
 <div data-type="page" id="apple">
@@ -63,8 +63,8 @@
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -83,15 +83,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
 
     </div>
 
@@ -106,14 +106,14 @@
     <li>Apple sauce...</li>
 </ul>
   </div>
-<div data-type="page" id="lemon" class="fruity">
+<div class="fruity" data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -132,15 +132,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -150,7 +150,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_74606">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_8271"></img></p>
+<p id="auto_lemon_74606">Yum! <img id="auto_lemon_8271" src="/resources/1x1.jpg"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -162,14 +162,14 @@
   </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Citrus</h1>
-<div data-type="page" id="lemon" class="fruity">
+<div class="fruity" data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -188,15 +188,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -206,7 +206,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_33432">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_15455"></img></p>
+<p id="auto_lemon_33432">Yum! <img id="auto_lemon_15455" src="/resources/1x1.jpg"></img></p>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -220,12 +220,12 @@
 </div>
 <div data-type="page" id="chocolate">
 <div data-type="metadata">
-      <h1 data-type="document-title" itemprop="name">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</h1>
+      <h1 data-type="document-title" itemprop="name">チョコレート</h1>
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -244,15 +244,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
       <div data-type="resources" style="display: none">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -267,7 +267,7 @@
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_99740"></img><p id="auto_chocolate_58915">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
+</ul></div><img id="auto_chocolate_99740" src="/resources/1x1.jpg"></img><p id="auto_chocolate_58915">チョコレートデザート</p>
   </div>
 <div data-type="composite-page" id="extra">
 <div data-type="metadata">
@@ -275,8 +275,8 @@
 
       <div class="authors">
         By:
-<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
-            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
           </span>
         Edited by:
 
@@ -295,15 +295,15 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
 
-      <div class="description" itemprop="description" data-type="description">
+      <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div>
 
-<div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">&#12487;&#12470;&#12540;&#12488;</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
 
     </div>
 

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -351,7 +351,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertTrue(expected_nav in nav)
 
         # Check that translucent is set
-        self.assertTrue('<span data-type="binding" data-value="translucent" />' in nav)
+        self.assertTrue('<span data-type="binding" data-value="translucent"' in nav)
 
         # Check the title and content
         self.assertTrue('<title>Kraken</title>' in nav)
@@ -465,7 +465,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertIn(expected_nav, nav)
 
         # Check that translucent is set
-        self.assertTrue('<span data-type="binding" data-value="translucent" />' in nav)
+        self.assertTrue('<span data-type="binding" data-value="translucent"' in nav)
 
         # Check the title and content
         self.assertTrue('<title>Kraken</title>' in nav)
@@ -476,7 +476,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertTrue(re.search(
             '<div data-type="resources"[^>]*>\s*<ul>\s*'
             '<li>\s*<a href="1x1.jpg">1x1.jpg</a>\s*</li>\s*</ul>\s*</div>', egress))
-        self.assertTrue(u'<p><img src="../resources/1x1.jpg"/>hüvasti.</p>' in egress)
+        self.assertTrue(u'<p><img src="../resources/1x1.jpg"></img>hüvasti.</p>' in egress)
 
         # Adapt epub back to documents and binders
         from cnxepub import EPUB
@@ -605,7 +605,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertTrue(u'<a href="cover.png">cover.png</a>' in nav)
 
         # Check that translucent is not set
-        self.assertFalse('<span data-type="binding" data-value="translucent" />' in nav)
+        self.assertFalse('<span data-type="binding" data-value="translucent"' in nav)
 
         # Check the title and content
         self.assertTrue(u'<title>Kraken (Nueva Versión)</title>' in nav)
@@ -615,7 +615,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
             ingress = unescape(f.read())
         self.assertTrue('<title>egress</title>' in egress)
         self.assertTrue('<span data-type="cnx-archive-uri" '
-                        'data-value="e78d4f90-e078-49d2-beac-e95e8be70667" />' in egress)
+                        'data-value="e78d4f90-e078-49d2-beac-e95e8be70667"' in egress)
         self.assertTrue(u'<p>hüvasti.</p>' in egress)
         self.assertFalse('Derived from:' in egress)
         self.assertTrue('Derived from:' in ingress)
@@ -626,9 +626,9 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         with open(os.path.join(epub_path, 'contents', pointer_filename)) as f:
             pointer = unescape(f.read())
         self.assertTrue('<title>Pointer</title>' in pointer)
-        self.assertTrue('<span data-type="document" data-value="pointer" />' in pointer)
+        self.assertTrue('<span data-type="document" data-value="pointer"' in pointer)
         self.assertTrue('<span data-type="cnx-archive-uri" '
-                        'data-value="pointer@1" />' in pointer)
+                        'data-value="pointer@1"' in pointer)
         self.assertTrue('<a href="http://cnx.org/contents/pointer@1">here</a>' in pointer)
 
         # Adapt epub back to documents and binders
@@ -749,8 +749,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, lemon_metadata)
-        self.assertIn('<p id="74606">Yum! <img src="/resources/1x1.jpg" '
-                      'id="8271"/></p>', lemon.content)
+        self.assertIn('<p id="74606">Yum! <img id="8271" '
+                      'src="/resources/1x1.jpg"/></p>', lemon.content)
         self.assertEqual('<span>1.1</span> <span>|</span> <span>'
                          '&#12524;&#12514;&#12531;</span>',
                          fruity.get_title_for_node(lemon))


### PR DESCRIPTION
This code runs extra parsing steps on output of HTML from EPUB, to cleanup and regularize the namespaces. The output HTML is semantically identical to the previous version - the changes are purely syntax, making for a more human-readable output.