### PR TITLE
implement includes callback

### DIFF
--- a/cnxepub/collation.py
+++ b/cnxepub/collation.py
@@ -51,21 +51,19 @@ def reconstitute(html):
     return adapt_single_html(xhtml)
 
 
-def collate(binder):
+def collate(binder, ruleset="ruleset.css", includes=None):
     """Given a ``Binder`` as ``binder``, collate the content into a new set
     of models.
     Returns the collated binder.
 
     """
-    html_formatter = SingleHTMLFormatter(binder)
+    html_formatter = SingleHTMLFormatter(binder, includes)
     raw_html = io.BytesIO(bytes(html_formatter))
     collated_html = io.BytesIO()
 
-    # FIXME Seems like there should be a more definitive way
-    # to get the ruleset file.
     try:
         ruleset_resource = [r for r in binder.resources
-                            if r.filename == 'ruleset.css'][0]
+                            if r.filename == ruleset][0]
     except IndexError:
         # No ruleset found, so no cooking necessary.
         return binder

--- a/cnxepub/data_uri.py
+++ b/cnxepub/data_uri.py
@@ -4,6 +4,7 @@
 import mimetypes
 import re
 import urllib
+import textwrap
 
 
 MIMETYPE_REGEX = r'[\w]+\/[\w\-\+\.]+'

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -195,7 +195,7 @@ class HTMLFormatter(object):
 
 
 class SingleHTMLFormatter(object):
-    def __init__(self, binder):
+    def __init__(self, binder, includes=None):
         self.binder = binder
 
         self.root = etree.fromstring(bytes(HTMLFormatter(self.binder)))
@@ -204,6 +204,7 @@ class SingleHTMLFormatter(object):
         self.body = self.xpath('//xhtml:body')[0]
 
         self.built = False
+        self.includes = includes
 
     def xpath(self, path, elem=None):
         if elem is None:
@@ -251,6 +252,12 @@ class SingleHTMLFormatter(object):
 
     def build(self):
         self._build_binder(self.binder, self.body)
+        # Fetch any includes from remote sources
+        if self.includes is not None:
+            for match, proc in self.includes:
+                for elem in self.xpath(match):
+                    proc(elem)
+
         # Rewrite absolute-path links that are intra-binder
         page_ids = [page.id for page in flatten_to_documents(self.binder)]
         page_uuids = {id.split('@')[0]: id for id in page_ids}

--- a/cnxepub/tests/data/desserts-single-page-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-includes-py2.xhtml
@@ -1,0 +1,316 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Desserts</title>
+    <meta content="" data-type="language" itemprop="inLanguage"></meta>
+
+    
+    <meta content="MathML" itemprop="accessibilityFeature"></meta>
+    <meta content="LaTeX" itemprop="accessibilityFeature"></meta>
+    <meta content="alternativeText" itemprop="accessibilityFeature"></meta>
+    <meta content="captions" itemprop="accessibilityFeature"></meta>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"></meta>
+
+
+    <meta content="" itemprop="dateCreated"></meta>
+    <meta content="" itemprop="dateModified"></meta>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Desserts</h1>
+
+      <div class="authors">
+        By:
+
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="" itemprop="dc:license,lrmi:useRightsURL"></a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        
+      </div>
+
+
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="cover.png">COVER.PNG</a></li>        </ul>
+      </div>
+    </div>
+
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">APPLE</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+  <div data-type="unit">
+<h1 data-type="document-title">Fruity</h1>
+<div data-type="page" id="apple">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Apple</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+
+    </div>
+
+   <h1>Apple Desserts</h1>
+
+<p id="auto_apple_13436"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
+
+<ul><li>Apple Crumble,</li>
+    <li>Apfelstrudel,</li>
+    <li>Caramel Apple,</li>
+    <li>Apple Pie,</li>
+    <li>Apple sauce...</li>
+</ul>
+  </div>
+<div class="fruity" data-type="page" id="lemon">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
+      </div>
+    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_84744">Yum! <img id="auto_lemon_76378" src="/resources/1x1.jpg"></img></p>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div>
+<div data-type="chapter">
+<h1 data-type="document-title">Citrus</h1>
+<div class="fruity" data-type="page" id="lemon">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
+      </div>
+    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_25507">Yum! <img id="auto_lemon_49544" src="/resources/1x1.jpg"></img></p>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div>
+</div>
+</div>
+<div data-type="page" id="chocolate">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
+      </div>
+    </div>
+
+   <h1>Chocolate Desserts</h1>
+
+<p id="auto_chocolate_44949"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
+
+<div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
+    <li>Hot Mocha Puddings,</li>
+    <li>Chocolate and Banana French Toast,</li>
+    <li>Chocolate Truffles...</li>
+</ul></div><img id="auto_chocolate_65159" src="/resources/1x1.jpg"></img><p id="auto_chocolate_78873">チョコレートデザート</p>
+  </div>
+<div data-type="composite-page" id="extra">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+
+    </div>
+
+   <h1>Extra Stuff</h1>
+
+<p id="auto_extra_9386">This is a composite page.</p>
+
+<p id="auto_extra_2834">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
+  </div></body>
+</html>

--- a/cnxepub/tests/data/desserts-single-page-includes.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-includes.xhtml
@@ -1,0 +1,316 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Desserts</title>
+    <meta content="" data-type="language" itemprop="inLanguage"></meta>
+
+    
+    <meta content="MathML" itemprop="accessibilityFeature"></meta>
+    <meta content="LaTeX" itemprop="accessibilityFeature"></meta>
+    <meta content="alternativeText" itemprop="accessibilityFeature"></meta>
+    <meta content="captions" itemprop="accessibilityFeature"></meta>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"></meta>
+
+
+    <meta content="" itemprop="dateCreated"></meta>
+    <meta content="" itemprop="dateModified"></meta>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Desserts</h1>
+
+      <div class="authors">
+        By:
+
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="" itemprop="dc:license,lrmi:useRightsURL"></a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        
+      </div>
+
+
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="cover.png">COVER.PNG</a></li>        </ul>
+      </div>
+    </div>
+
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">APPLE</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+  <div data-type="unit">
+<h1 data-type="document-title">Fruity</h1>
+<div data-type="page" id="apple">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Apple</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+
+    </div>
+
+   <h1>Apple Desserts</h1>
+
+<p id="auto_apple_17611"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
+
+<ul><li>Apple Crumble,</li>
+    <li>Apfelstrudel,</li>
+    <li>Caramel Apple,</li>
+    <li>Apple Pie,</li>
+    <li>Apple sauce...</li>
+</ul>
+  </div>
+<div class="fruity" data-type="page" id="lemon">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
+      </div>
+    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_74606">Yum! <img id="auto_lemon_8271" src="/resources/1x1.jpg"></img></p>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div>
+<div data-type="chapter">
+<h1 data-type="document-title">Citrus</h1>
+<div class="fruity" data-type="page" id="lemon">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
+      </div>
+    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_33432">Yum! <img id="auto_lemon_15455" src="/resources/1x1.jpg"></img></p>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div>
+</div>
+</div>
+<div data-type="page" id="chocolate">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
+      </div>
+    </div>
+
+   <h1>Chocolate Desserts</h1>
+
+<p id="auto_chocolate_64937"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
+
+<div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
+    <li>Hot Mocha Puddings,</li>
+    <li>Chocolate and Banana French Toast,</li>
+    <li>Chocolate Truffles...</li>
+</ul></div><img id="auto_chocolate_99740" src="/resources/1x1.jpg"></img><p id="auto_chocolate_58915">チョコレートデザート</p>
+  </div>
+<div data-type="composite-page" id="extra">
+<div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+        Published By:
+      </div>
+
+
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>
+
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div>
+
+<div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+
+    </div>
+
+   <h1>Extra Stuff</h1>
+
+<p id="auto_extra_61898">This is a composite page.</p>
+
+<p id="auto_extra_85405">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
+  </div></body>
+</html>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -454,3 +454,31 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             self.assertMultiLineEqual(
                 html,
                 unicode(SingleHTMLFormatter(self.desserts)).encode('utf-8'))
+
+    def test_includes_callback(self):
+        import random
+
+        from ..formatters import SingleHTMLFormatter
+
+        def _upcase_text(elem):
+            if elem.text:
+                elem.text = elem.text.upper()
+
+        random.seed(1)
+        page_path = os.path.join(TEST_DATA_DIR, 'desserts-single-page-includes.xhtml')
+        if not IS_PY3:
+            page_path = page_path.replace('.xhtml', '-py2.xhtml')
+
+        with open(page_path, 'r') as f:
+            expected_content = f.read()
+
+        actual = str(SingleHTMLFormatter(self.desserts, [('//xhtml:a', _upcase_text)]))
+        out_path = os.path.join(TEST_DATA_DIR, 'desserts-single-page-includes-actual.xhtml')
+        if not IS_PY3:
+            out_path = out_path.replace('.xhtml', '-py2.xhtml')
+        with open(out_path, 'w') as out:
+            out.write(actual)
+
+        self.assertMultiLineEqual(expected_content, actual)
+        # After assert, so won't clean up if test fails
+        os.remove(out_path)


### PR DESCRIPTION
In support of pulling exercises from a remote server into the raw HTML, so that it is present at cooking, this code extends the SingleHTMLFormatter to take a list of tuples, as `(xpath, callback)` pairs. When the single HTML page has been built, these callbacks are called, once with each element that matches the `xpath`. Test example matches all `a` elements, and upcases the link text.

Next step is for publish to build a callback for inserting exercises, based on config values.