### PR TITLE
when replacing math, move tail text

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -342,6 +342,7 @@ def _replace_tex_math(node, mml_url, depth=0):
                 mml.set('display', 'inline')
             elif node.tag.endswith('div'):
                 mml.set('display', 'block')
+            mml.tail = node.tail
             return mml
         else:
             logger.warning('Retrying math TeX conversion: '

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -373,7 +373,7 @@
                   <m:mn>2</m:mn>
                 </m:msub>
                 <m:mtext>O</m:mtext>
-              </m:math>
+              </m:math>)
             </li>
             <li
               data-correctness='1.0'
@@ -386,7 +386,7 @@
                   <m:mn>2</m:mn>
                 </m:msub>
                 <m:mtext>O</m:mtext>
-              </m:math>
+              </m:math>)
             </li>
           </ol>
         </div>
@@ -538,7 +538,7 @@
                     <m:mn>2</m:mn>
                   </m:msub>
                   <m:mtext>O</m:mtext>
-                </m:math>
+                </m:math>)
               </li>
               <li
                 data-correctness='1.0'
@@ -551,7 +551,7 @@
                     <m:mn>2</m:mn>
                   </m:msub>
                   <m:mtext>O</m:mtext>
-                </m:math>
+                </m:math>)
               </li>
             </ol>
           </div>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -157,14 +157,14 @@
     <m:mn>2</m:mn>
   </m:msub>
   <m:mtext>O</m:mtext>
-</m:math></li>
+</m:math>)</li>
                     <li data-correctness="1.0">polymer and water (<m:math display="block">
   <m:msub>
     <m:mtext>H</m:mtext>
     <m:mn>2</m:mn>
   </m:msub>
   <m:mtext>O</m:mtext>
-</m:math></li>
+</m:math>)</li>
             </ol>
 </div>
 
@@ -237,14 +237,14 @@
     <m:mn>2</m:mn>
   </m:msub>
   <m:mtext>O</m:mtext>
-</m:math></li>
+</m:math>)</li>
                     <li data-correctness="1.0">polymer and water (<m:math display="block">
   <m:msub>
     <m:mtext>H</m:mtext>
     <m:mn>2</m:mn>
   </m:msub>
   <m:mtext>O</m:mtext>
-</m:math></li>
+</m:math>)</li>
             </ol>
 </div>
 


### PR DESCRIPTION
oops. The text after an inline math node was being deleted.