### PR TITLE
add default for the mathmlcloud URL commandline argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage
   - pip install coveralls
+  - pip install lxml==3.6.4
   # FIXME (18-Apr-2016) cnx-easybake requires an unreleased package, cssselect2
   - pip install git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
   # Install cnx-easybake

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage
   - pip install coveralls
+  # FIXME travis fails w/ 3.7.0 on python3, even though it works locally
   - pip install lxml==3.6.4
   # FIXME (18-Apr-2016) cnx-easybake requires an unreleased package, cssselect2
   - pip install git+https://github.com/Connexions/cssselect2.git#egg=cssselect2

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -468,6 +468,9 @@ DOCUMENT_POINTER_TEMPLATE = """\
       {% if metadata.get('cnx-archive-uri') %}
       <span data-type="cnx-archive-uri" data-value="{{ \
           metadata['cnx-archive-uri'] }}" />
+      {%- endif %}{% if metadata.get('cnx-archive-shortid') %}
+      <span data-type="cnx-archive-shortid" data-value="{{ \
+          metadata['cnx-archive-shortid'] }}" />
       {%- endif %}
     </div>
 
@@ -539,6 +542,10 @@ HTML_DOCUMENT = """\
       {% if metadata.get('cnx-archive-uri') %}
       <span data-type="cnx-archive-uri" data-value="{{ \
           metadata['cnx-archive-uri'] }}" />
+      {% if metadata.get('cnx-archive-shortid') %}
+      <span data-type="cnx-archive-shortid" data-value="{{ \
+          metadata['cnx-archive-shortid'] }}" />
+      {%- endif %}
       {%- endif %}
 
       <div class="authors">

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -103,8 +103,8 @@ class DocumentMetadataParser:
         'created', 'revised', 'language', 'subjects', 'keywords',
         'license_text', 'editors', 'illustrators', 'translators',
         'publishers', 'copyright_holders', 'authors', 'summary',
-        'cnx-archive-uri', 'derived_from_uri', 'derived_from_title',
-        'print_style',
+        'cnx-archive-uri', 'cnx-archive-shortid', 'derived_from_uri',
+        'derived_from_title', 'print_style',
         )
 
     def __init__(self, elm_tree, raise_value_error=True):
@@ -276,6 +276,13 @@ class DocumentMetadataParser:
             return items[0]
 
     @property
+    def cnx_archive_shortid(self):
+        items = self.parse(
+            './/xhtml:*[@data-type="cnx-archive-shortid"]/@data-value')
+        if items:
+            return items[0]
+
+    @property
     def derived_from_uri(self):
         items = self.parse('.//xhtml:*[@data-type="derived-from"]/@href')
         if items:
@@ -299,7 +306,7 @@ class DocumentPointerMetadataParser(DocumentMetadataParser):
             'title', 'cnx-archive-uri', 'is_document_pointer',
             )
     metadata_optional_keys = DocumentMetadataParser.metadata_optional_keys + (
-            'license_url', 'summary',
+            'license_url', 'summary', 'cnx-archive-shortid',
             )
 
     @property

--- a/cnxepub/scripts/single_html/main.py
+++ b/cnxepub/scripts/single_html/main.py
@@ -89,6 +89,9 @@ def main(argv=None):
     parser.add_argument('-m', "--mathjax_version", const=DEFAULT_MATHJAX_VER,
                         metavar="mathjax_version", nargs="?",
                         help="Add script tag to use MathJax of given version")
+    parser.add_argument('-n', "--no-network", action='store_true',
+                        help="Do not use network access "
+                        "- no exercise or math conversion")
     parser.add_argument('-x', "--exercise_host",
                         const=DEFAULT_EXERCISES_HOST,
                         metavar="exercise_host", nargs="?",
@@ -123,7 +126,7 @@ def main(argv=None):
     exercise_host = args.exercise_host or DEFAULT_EXERCISES_HOST
     exercise_token = args.exercise_token
     mml_url = args.mathmlcloud_url or DEFAULT_MATHMLCLOUD_URL
-    if exercise_host:
+    if not args.no_network:
         exercise_url = \
                 'https://%s/api/exercises?q=tag:{itemCode}' % (exercise_host)
         exercise_match = '#ost/api/ex/'

--- a/cnxepub/scripts/single_html/main.py
+++ b/cnxepub/scripts/single_html/main.py
@@ -120,9 +120,9 @@ def main(argv=None):
         if not mathjax_version.endswith('latest'):
             mathjax_version += '-latest'
 
-    exercise_host = args.exercise_host
+    exercise_host = args.exercise_host or DEFAULT_EXERCISES_HOST
     exercise_token = args.exercise_token
-    mml_url = args.mathmlcloud_url
+    mml_url = args.mathmlcloud_url or DEFAULT_MATHMLCLOUD_URL
     if exercise_host:
         exercise_url = \
                 'https://%s/api/exercises?q=tag:{itemCode}' % (exercise_host)

--- a/cnxepub/scripts/single_html/main.py
+++ b/cnxepub/scripts/single_html/main.py
@@ -20,6 +20,10 @@ ARCHIVEHTML = 'https://archive.cnx.org/contents/{}.html'
 MATHJAX_URL = 'https://cdn.mathjax.org/mathjax/{mathjax_version}/'\
               'unpacked/MathJax.js?config=MML_HTMLorMML'
 
+DEFAULT_MATHJAX_VER = 'latest'
+DEFAULT_EXERCISES_HOST = 'exercises.openstax.org'
+DEFAULT_MATHMLCLOUD_URL = 'http://mathmlcloud.cnx.org:1337/equation/'
+
 
 parts = ['page', 'chapter', 'unit', 'book', 'series']
 partcount = {}
@@ -82,11 +86,11 @@ def main(argv=None):
                         type=argparse.FileType('w'),
                         help="assembled HTML file output (default stdout)",
                         default=sys.stdout)
-    parser.add_argument('-m', "--mathjax_version", const="latest",
+    parser.add_argument('-m', "--mathjax_version", const=DEFAULT_MATHJAX_VER,
                         metavar="mathjax_version", nargs="?",
                         help="Add script tag to use MathJax of given version")
     parser.add_argument('-x', "--exercise_host",
-                        const="exercises.openstax.org",
+                        const=DEFAULT_EXERCISES_HOST,
                         metavar="exercise_host", nargs="?",
                         help="Download included exercises from this host")
     parser.add_argument('-t', "--exercise_token",
@@ -95,7 +99,8 @@ def main(argv=None):
     parser.add_argument('-M', "--mathmlcloud_url",
                         metavar="mathmlcloud_url", nargs="?",
                         help="Convert TeX equations using "
-                             "this mathmlcloud API url")
+                             "this mathmlcloud API url",
+                        const=DEFAULT_MATHMLCLOUD_URL)
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Send debugging info to stderr')
     parser.add_argument('-s', '--subset-chapters', dest='numchapters',

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -19,6 +19,7 @@
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
+      <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
@@ -86,6 +87,7 @@
   <div data-type="unit"><h1 data-type="document-title">Part One</h1><div data-type="chapter"><h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
@@ -152,6 +154,7 @@
   </div></div><div data-type="chapter"><h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
@@ -218,6 +221,7 @@
   </div></div></div><div data-type="unit"><h1 data-type="document-title">Part Two</h1><div data-type="chapter"><h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -19,6 +19,7 @@
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
+      <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
@@ -86,6 +87,7 @@
   <div data-type="unit"><h1 data-type="document-title">Part One</h1><div data-type="chapter"><h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
@@ -152,6 +154,7 @@
   </div></div><div data-type="chapter"><h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
@@ -218,6 +221,7 @@
   </div></div></div><div data-type="unit"><h1 data-type="document-title">Part Two</h1><div data-type="chapter"><h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">

--- a/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
+++ b/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
@@ -46,6 +46,7 @@
       <!-- //@itemprop='name' is perferred over //title -->
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6" />
+      <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6" />
 
       <div class="authors">
         By: 

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -50,6 +50,7 @@
       <!-- //@itemprop='name' is perferred over //title -->
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3" />
+      <span data-type="cnx-archive-shortid" data-value="541PkOB4@3" />
 
       <div class="authors">
         By: 

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -182,6 +182,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'derived_from_uri': u'http://example.org/contents/id@ver',
             u'derived_from_title': u'Wild Grains and Warted Feet',
             u'cnx-archive-uri': None,
+            u'cnx-archive-shortid': None,
             u'language': None,
             u'print_style': u'* print style *',
             }
@@ -665,6 +666,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         u'language': None,
         u'print_style': None,
         u'cnx-archive-uri': None,
+        u'cnx-archive-shortid': None,
         u'derived_from_title': None,
         u'derived_from_uri': None,
         }

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -107,6 +107,7 @@ class ReconstituteTestCase(unittest.TestCase):
             u'language': None,
             u'print_style': None,
             u'cnx-archive-uri': None,
+            u'cnx-archive-shortid': None,
             u'derived_from_title': None,
             u'derived_from_uri': None,
             }

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -57,6 +57,7 @@ class HTMLParsingTestCase(unittest.TestCase):
             'translators': [{'id': None, 'name': 'Francis Hablar',
                              'type': None}],
             'cnx-archive-uri': 'e78d4f90-e078-49d2-beac-e95e8be70667@3',
+            'cnx-archive-shortid': '541PkOB4@3',
             'derived_from_uri': 'http://example.org/contents/id@ver',
             'derived_from_title': 'Wild Grains and Warted Feet',
             'print_style': '* print style *',


### PR DESCRIPTION
I had trouble finding the API URL (and port) for the currently-running MathMLCloud instance. It might be better to switch it to run on 443 (instead of 1337) but this at least documents it a little bit more.

@reedstrm remembered the URL by looking through the tests although it seems the tests use port 80

Also, I did not test this code, just cargo-culted to make sure the bits were not lost