### PR TITLE
Copy resources

### DIFF
--- a/cnxepub/epub.py
+++ b/cnxepub/epub.py
@@ -109,7 +109,7 @@ def pack_epub(directory, file):
     """Pack the given ``directory`` into an epub (i.e. zip) archive
     given as ``file``, which can be a file-path or file-like object.
     """
-    with zipfile.ZipFile(file, 'w') as zippy:
+    with zipfile.ZipFile(file, 'w', zipfile.ZIP_DEFLATED) as zippy:
         base_path = os.path.abspath(directory)
         for root, dirs, filenames in os.walk(directory):
             # Strip the absolute path

--- a/cnxepub/scripts/collated_single_html/main.py
+++ b/cnxepub/scripts/collated_single_html/main.py
@@ -42,13 +42,15 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
 
+    if args.input and args.output == sys.stdout:
+        raise ValueError('Cannot output to stdout if reading resources')
+
     from cnxepub.collation import reconstitute
     binder = reconstitute(args.collated_html)
 
     if args.dump_tree:
         print(pformat(cnxepub.model_to_tree(binder)),
               file=sys.stdout)
-
     if args.output:
         cnxepub.adapters.make_epub(binder, args.output)
 


### PR DESCRIPTION
This enables a workflow for creating the baked zip directly from the raw epub and the baked single-page html file. Note I went with the second parameter, since it's both more explicit, and probably more scriptable.