### PR TITLE
make missing exercises explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage
-  - pip install coveralls
+  - pip install codecov
   # FIXME travis fails w/ 3.7.0 on python3, even though it works locally
   - pip install lxml==3.6.4
   # FIXME (18-Apr-2016) cnx-easybake requires an unreleased package, cssselect2
@@ -22,7 +22,7 @@ before_script:
 script:
   - coverage run --source=cnxepub -m unittest discover
 after_success:
-  # Report test coverage to coveralls.io
-  - coveralls
+  # Report test coverage to codecov.io
+  - codecov
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@ Running tests
 .. image:: https://travis-ci.org/Connexions/cnx-epub.png?branch=master
    :target: https://travis-ci.org/Connexions/cnx-epub
 
+.. image:: https://codecov.io/gh/Connexions/cnx-epub/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/Connexions/cnx-epub
+  
 Either of the following will work::
 
     $ python -m unittest discover

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -397,8 +397,9 @@ def exercise_callback_factory(match, url_template, token=None, mml_url=None):
                             mparent = node.getparent()
                             mparent.replace(node, mathml)
                         else:
+                            mathtext = node.text or ''
                             logger.warning('BAD TEX CONVERSION: "%s" URL: %s'
-                                           % (node.text.encode('utf-8'), url))
+                                           % (mathtext.encode('utf-8'), url))
 
             parent = elem.getparent()
             if etree.QName(parent.tag).localname == 'p':

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -397,7 +397,7 @@ def exercise_callback_factory(match, url_template, token=None, mml_url=None):
                             mparent = node.getparent()
                             mparent.replace(node, mathml)
                         else:
-                            mathtext = node.text or ''
+                            mathtext = node.get('data-math') or node.text or ''
                             logger.warning('BAD TEX CONVERSION: "%s" URL: %s'
                                            % (mathtext.encode('utf-8'), url))
 

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -361,7 +361,11 @@
         <div
           data-type='exercise'
           id='auto_lemon_49544'
-        ></div>
+        >
+          <div
+            class='missing-exercise'
+          >MISSING EXERCISE: tag:nosuchtag</div>
+        </div>
         <ul>
           <li>Lemon &amp; Lime Crush,</li>
           <li>Lemon Drizzle Loaf,</li>
@@ -495,7 +499,11 @@
           <div
             data-type='exercise'
             id='auto_lemon_2834'
-          ></div>
+          >
+            <div
+              class='missing-exercise'
+            >MISSING EXERCISE: tag:nosuchtag</div>
+          </div>
           <ul>
             <li>Lemon &amp; Lime Crush,</li>
             <li>Lemon Drizzle Loaf,</li>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -358,7 +358,11 @@
             >monomers</li>
             <li
               data-correctness='1.0'
-            >polymers</li>
+            >polymers (
+              <span
+                data-math='retry'
+              ></span>)
+            </li>
             <li
               data-correctness='0.0'
             >carbohydrates only (
@@ -531,7 +535,11 @@
               >monomers</li>
               <li
                 data-correctness='1.0'
-              >polymers</li>
+              >polymers (
+                <span
+                  data-math='retry'
+                ></span>)
+              </li>
               <li
                 data-correctness='0.0'
               >carbohydrates only (

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -361,7 +361,11 @@
             >polymers</li>
             <li
               data-correctness='0.0'
-            >carbohydrates only</li>
+            >carbohydrates only (
+              <span
+                data-math=''
+              ></span>)
+            </li>
             <li
               data-correctness='0.0'
             >water only (
@@ -530,7 +534,11 @@
               >polymers</li>
               <li
                 data-correctness='0.0'
-              >carbohydrates only</li>
+              >carbohydrates only (
+                <span
+                  data-math=''
+                ></span>)
+              </li>
               <li
                 data-correctness='0.0'
               >water only (

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -393,7 +393,11 @@
         <div
           data-type='exercise'
           id='auto_lemon_49544'
-        ></div>
+        >
+          <div
+            class='missing-exercise'
+          >MISSING EXERCISE: tag:nosuchtag</div>
+        </div>
         <ul>
           <li>Lemon &amp; Lime Crush,</li>
           <li>Lemon Drizzle Loaf,</li>
@@ -558,7 +562,11 @@
           <div
             data-type='exercise'
             id='auto_lemon_2834'
-          ></div>
+          >
+            <div
+              class='missing-exercise'
+            >MISSING EXERCISE: tag:nosuchtag</div>
+          </div>
           <ul>
             <li>Lemon &amp; Lime Crush,</li>
             <li>Lemon Drizzle Loaf,</li>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -171,7 +171,7 @@
 
 
 <div data-type="exercise" id="auto_lemon_15455">
-    </div>
+    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -251,7 +251,7 @@
 
 
 <div data-type="exercise" id="auto_lemon_85405">
-    </div>
+    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -150,7 +150,7 @@
             <ol data-number-style="lower-alpha">
                     <li data-correctness="0.0">monomers</li>
                     <li data-correctness="1.0">polymers</li>
-                    <li data-correctness="0.0">carbohydrates only</li>
+                    <li data-correctness="0.0">carbohydrates only (<span data-math=""/>)</li>
                     <li data-correctness="0.0">water only (<m:math display="inline">
   <m:msub>
     <m:mtext>H</m:mtext>
@@ -230,7 +230,7 @@
             <ol data-number-style="lower-alpha">
                     <li data-correctness="0.0">monomers</li>
                     <li data-correctness="1.0">polymers</li>
-                    <li data-correctness="0.0">carbohydrates only</li>
+                    <li data-correctness="0.0">carbohydrates only (<span data-math=""/>)</li>
                     <li data-correctness="0.0">water only (<m:math display="inline">
   <m:msub>
     <m:mtext>H</m:mtext>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -149,7 +149,7 @@
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
                     <li data-correctness="0.0">monomers</li>
-                    <li data-correctness="1.0">polymers</li>
+                    <li data-correctness="1.0">polymers (<span data-math="retry"/>)</li>
                     <li data-correctness="0.0">carbohydrates only (<span data-math=""/>)</li>
                     <li data-correctness="0.0">water only (<m:math display="inline">
   <m:msub>
@@ -229,7 +229,7 @@
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
                     <li data-correctness="0.0">monomers</li>
-                    <li data-correctness="1.0">polymers</li>
+                    <li data-correctness="1.0">polymers (<span data-math="retry"/>)</li>
                     <li data-correctness="0.0">carbohydrates only (<span data-math=""/>)</li>
                     <li data-correctness="0.0">water only (<m:math display="inline">
   <m:msub>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -158,7 +158,7 @@
 
 
 <div data-type="exercise" id="auto_lemon_15455">
-    </div>
+    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -225,7 +225,7 @@
 
 
 <div data-type="exercise" id="auto_lemon_85405">
-    </div>
+    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -94,7 +94,7 @@ EXERCISE_JSON_HTML = {
                      "correctness": "0.0"
                   },
                   {
-                     "content_html": "polymers",
+                     "content_html": "polymers (<span data-math='retry' />)",
                      "id": 259957,
                      "correctness": "1.0"
 
@@ -289,6 +289,8 @@ def mocked_requests_post(*args, **kwargs):
     if args[0].startswith('http://mathmlcloud.cnx.org/equation'):
         if args[1]['math'] == b'\\text{H}_2\\text{O}':
             return MockResponse(EQUATION_JSON, 200)
+        elif args[1]['math'] == b'retry':
+            return MockResponse('{}', 200)
         elif args[1]['math'] == b'':
             return MockResponse(BAD_EQUATION_JSON, 400)
         else:

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -53,6 +53,7 @@ def last_extension(*args, **kwargs):
     exts = mimetypes.guess_all_extensions(*args, **kwargs)
     return sorted(exts)[-1]
 
+
 EXERCISE_JSON_HTML = {
    "items": [
       {
@@ -100,7 +101,7 @@ EXERCISE_JSON_HTML = {
                   },
                   {
                      "id": 259958,
-                     "content_html": "carbohydrates only",
+                     "content_html": "carbohydrates only (<span data-math='' />)",
                      "correctness": "0.0"
                   },
                   {
@@ -227,6 +228,17 @@ EXERCISE_JSON = {
    "total_count": 1
 }
 
+BAD_EQUATION_JSON = {
+    "error": "E_VALIDATION",
+    "status": 400,
+    "summary": "1 attribute is invalid",
+    "model": "Equation",
+    "invalidAttributes": {
+        "math": [{"rule": "required",
+                  "message": "\"required\" validation rule failed for input: ''\nSpecifically, it threw an error.  Details:\n undefined"}]
+        }
+    }
+
 
 EQUATION_JSON = {
     "updatedAt": "2016-10-31T16:06:44.413Z",
@@ -275,7 +287,12 @@ def mocked_requests_get(*args, **kwargs):
 
 def mocked_requests_post(*args, **kwargs):
     if args[0].startswith('http://mathmlcloud.cnx.org/equation'):
+        if args[1]['math'] == b'\\text{H}_2\\text{O}':
             return MockResponse(EQUATION_JSON, 200)
+        elif args[1]['math'] == b'':
+            return MockResponse(BAD_EQUATION_JSON, 400)
+        else:
+            return MockResponse('', 500)
     return MockResponse({}, 404)
 
 


### PR DESCRIPTION
Don't just delete missing exercises, leave a marker. (Which can then be used by a ruleset to delete more structure, if needed)
TeX conversion:
  + Convert the `data-math` attribute contents by preference.
  + Log bad TeX conversion.