### PR TITLE
change how ids are encoded in nav, to ease parsing and ruleset gen

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -794,23 +794,24 @@ def html_listify(tree, root_xl_element, extensions, list_type='ol'):
        in the epub, with associated filename extensions as the value. Those
        nodes will be rendered as links to the reassembled filename: i.e.
        id='abc-2345-54e4' {'abc-2345-54e4': 'xhtml'} -> abc-2345-54e4.xhtml
-       Other nodes will render as spans with cnx-archive-uri and
-       cnx-archive-shortid attributes"""
+       Other nodes will render as spans. If the node has id or short id values,
+       the associated li will be populated with cnx-archive-uri and
+       cnx-archive-shortid attributes, respectively"""
     for node in tree:
         li_elm = etree.SubElement(root_xl_element, 'li')
         if node['id'] not in extensions:  # no extension, no associated file
             span_elm = lxml.html.fragment_fromstring(
                 node['title'], create_parent='span')
-            if node['id'] is not None and node['id'] != 'subcol':
-                span_elm.set('cnx-archive-uri', node['id'])
-            if node['shortId'] is not None:
-                span_elm.set('cnx-archive-shortid', node['shortId'])
             li_elm.append(span_elm)
         else:
             a_elm = lxml.html.fragment_fromstring(
                 node['title'], create_parent='a')
             a_elm.set('href', ''.join([node['id'], extensions[node['id']]]))
             li_elm.append(a_elm)
+        if node['id'] is not None and node['id'] != 'subcol':
+            li_elm.set('cnx-archive-uri', node['id'])
+        if node['shortId'] is not None:
+            li_elm.set('cnx-archive-shortid', node['shortId'])
         if 'contents' in node:
             elm = etree.SubElement(li_elm, list_type)
             html_listify(node['contents'], elm, extensions)

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -73,7 +73,7 @@ def _nav_to_tree(root):
         else:
             # It's a node and should only have an li.
             a = li.xpath('xhtml:a', namespaces=HTML_DOCUMENT_NAMESPACES)[0]
-            yield {'id': li.get('cnx-archive-uri', a.get('href')),
+            yield {'id': a.get('href'),
                    'shortid': li.get('cnx-archive-shortid'),
                    'title': _squash_to_text(a, remove_namespaces=True)}
 

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -61,10 +61,9 @@ def _nav_to_tree(root):
                            if e.tag[e.tag.find('}')+1:] == 'ol'])
         if is_subtree:
             # It's a sub-tree and have a 'span' and 'ol'.
-            span = expath(li, 'xhtml:span')[0]
-            spanid = span.get('cnx-archive-uri') or 'subcol'
-            shortid = span.get('cnx-archive-shortid')
-            yield {'id': spanid,
+            itemid = li.get('cnx-archive-uri', 'subcol')
+            shortid = li.get('cnx-archive-shortid')
+            yield {'id': itemid,
                    # Title is wrapped in a span, div or some other element...
                    'title': _squash_to_text(expath(li, 'xhtml:*')[0],
                                             remove_namespaces=True),
@@ -74,7 +73,8 @@ def _nav_to_tree(root):
         else:
             # It's a node and should only have an li.
             a = li.xpath('xhtml:a', namespaces=HTML_DOCUMENT_NAMESPACES)[0]
-            yield {'id': a.get('href'),
+            yield {'id': li.get('cnx-archive-uri', a.get('href')),
+                   'shortid': li.get('cnx-archive-shortid'),
                    'title': _squash_to_text(a, remove_namespaces=True)}
 
 

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -75,7 +75,7 @@
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
+   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
   <div data-type="unit"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
       <span data-type="binding" data-value="translucent"/>    </div>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -75,7 +75,7 @@
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
+   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
   <div data-type="unit"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
       <span data-type="binding" data-value="translucent"/>    </div>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -82,17 +82,21 @@
       id='toc'
     >
       <ol>
-        <li>
-          <span
-            cnx-archive-uri='Fruity'
-          >Fruity</span>
+        <li
+          cnx-archive-uri='Fruity'
+        >
+          <span>Fruity</span>
           <ol>
-            <li>
+            <li
+              cnx-archive-uri='apple@draft'
+            >
               <a
                 href='apple@draft.xhtml'
               >APPLE</a>
             </li>
-            <li>
+            <li
+              cnx-archive-uri='lemon@draft'
+            >
               <a
                 href='lemon@draft.xhtml'
               >
@@ -108,7 +112,9 @@
                 <span>citrus</span>
               </span>
               <ol>
-                <li>
+                <li
+                  cnx-archive-uri='lemon@draft'
+                >
                   <a
                     href='lemon@draft.xhtml'
                   >LEMON</a>
@@ -117,12 +123,16 @@
             </li>
           </ol>
         </li>
-        <li>
+        <li
+          cnx-archive-uri='chocolate@draft'
+        >
           <a
             href='chocolate@draft.xhtml'
           >チョコレート</a>
         </li>
-        <li>
+        <li
+          cnx-archive-uri='extra@draft'
+        >
           <a
             href='extra@draft.xhtml'
           >EXTRA STUFF</a>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -83,17 +83,21 @@
       id='toc'
     >
       <ol>
-        <li>
-          <span
-            cnx-archive-uri='Fruity'
-          >Fruity</span>
+        <li
+          cnx-archive-uri='Fruity'
+        >
+          <span>Fruity</span>
           <ol>
-            <li>
+            <li
+              cnx-archive-uri='apple@draft'
+            >
               <a
                 href='apple@draft.xhtml'
               >APPLE</a>
             </li>
-            <li>
+            <li
+              cnx-archive-uri='lemon@draft'
+            >
               <a
                 href='lemon@draft.xhtml'
               >
@@ -109,7 +113,9 @@
                 <span>citrus</span>
               </span>
               <ol>
-                <li>
+                <li
+                  cnx-archive-uri='lemon@draft'
+                >
                   <a
                     href='lemon@draft.xhtml'
                   >LEMON</a>
@@ -118,12 +124,16 @@
             </li>
           </ol>
         </li>
-        <li>
+        <li
+          cnx-archive-uri='chocolate@draft'
+        >
           <a
             href='chocolate@draft.xhtml'
           >チョコレート</a>
         </li>
-        <li>
+        <li
+          cnx-archive-uri='extra@draft'
+        >
           <a
             href='extra@draft.xhtml'
           >EXTRA STUFF</a>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -30,7 +30,7 @@
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span cnx-archive-uri="Fruity">Fruity</span><ol><li><a href="apple@draft.xhtml">APPLE</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="Fruity"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="Fruity"/>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -30,7 +30,7 @@
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span cnx-archive-uri="Fruity">Fruity</span><ol><li><a href="apple@draft.xhtml">APPLE</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="Fruity"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="Fruity"/>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -30,7 +30,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span cnx-archive-uri="Fruity">Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="Fruity"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="Fruity"/>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -30,7 +30,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span cnx-archive-uri="Fruity">Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">チョコレート</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="Fruity"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="Fruity"/>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -352,12 +352,12 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         with open(os.path.join(epub_path, 'contents', navdoc_filename)) as f:
             nav = unescape(f.read())
         expected_nav = (
-                u'<nav id="toc"><ol><li>'
-                u'<a href="{}">entrée</a>'
-                u'</li><li>'
-                u'<a href="{}">egress</a>'
-                u'</li></ol></nav>'.format(ingress_filename, egress_filename))
-        self.assertTrue(expected_nav in nav)
+            u'<nav id="toc"><ol><li cnx-archive-uri="ingress@draft">'
+            u'<a href="{}">entrée</a>'
+            u'</li><li cnx-archive-uri="egress@draft">'
+            u'<a href="{}">egress</a>'
+            u'</li></ol></nav>'.format(ingress_filename, egress_filename))
+        self.assertIn(expected_nav, nav)
 
         # Check that translucent is set
         self.assertTrue('<span data-type="binding" data-value="translucent"' in nav)
@@ -466,11 +466,11 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         with open(os.path.join(epub_path, 'contents', navdoc_filename)) as f:
             nav = unescape(f.read())
         expected_nav = (
-                u'<nav id="toc"><ol><li>'
-                u'<a href="{}">entrée</a>'
-                u'</li><li>'
-                u'<a href="{}">egress</a>'
-                u'</li></ol></nav>'.format(ingress_filename, egress_filename))
+            u'<nav id="toc"><ol><li cnx-archive-uri="ingress@draft">'
+            u'<a href="{}">entrée</a>'
+            u'</li><li cnx-archive-uri="egress@draft">'
+            u'<a href="{}">egress</a>'
+            u'</li></ol></nav>'.format(ingress_filename, egress_filename))
         self.assertIn(expected_nav, nav)
 
         # Check that translucent is set
@@ -600,15 +600,16 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         # Check the nav
         with open(os.path.join(epub_path, 'contents', navdoc_filename)) as f:
             nav = unescape(f.read())
+
         expected_nav = (
-                u'<nav id="toc"><ol><li>'
-                u'<a href="{}">entrée</a>'
-                u'</li><li>'
-                u'<a href="{}">egress</a>'
-                u'</li><li>'
-                u'<a href="{}">Pointer</a>'
-                u'</li></ol></nav>'.format(ingress_filename, egress_filename,
-                                           pointer_filename))
+            u'<nav id="toc"><ol><li cnx-archive-uri="ingress@draft">'
+            u'<a href="{}">entrée</a>'
+            u'</li><li cnx-archive-uri="egress@draft">'
+            u'<a href="{}">egress</a>'
+            u'</li><li cnx-archive-uri="pointer@1">'
+            u'<a href="{}">Pointer</a>'
+            u'</li></ol></nav>'.format(ingress_filename, egress_filename,
+                                       pointer_filename))
         self.assertTrue(expected_nav in nav)
 
         # Check the resources


### PR DESCRIPTION
Change how we encoded and extract the object ids from the nav element in the navigation document, unifying treatment of pages and chapter/unit levels. There is an associated PR in recipes to maintain this same structure https://github.com/Connexions/cnx-recipes/pull/148