### PR TITLE
disallow @version in model ids, split them to id and metadata["version"]

### DIFF
--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -417,7 +417,7 @@ class Binder(TranslucentBinder):
             self._id = value
 
     @id.deleter
-    def id(self, value):
+    def id(self):
         del self._id
 
     @property
@@ -503,7 +503,7 @@ class Document(object):
             self._id = value
 
     @id.deleter
-    def id(self, value):
+    def id(self):
         del self._id
 
     @property

--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -405,6 +405,22 @@ class Binder(TranslucentBinder):
         self.resources = resources or []
 
     @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+
+        if value and '@' in value:
+            self._id, self.metadata['version'] = value.split('@')
+        else:
+            self._id = value
+
+    @id.deleter
+    def id(self, value):
+        del self._id
+
+    @property
     def ident_hash(self):
         if self.id is not None:
             args = [self.id]
@@ -415,6 +431,14 @@ class Binder(TranslucentBinder):
         else:
             value = None
         return value
+
+    @ident_hash.setter
+    def ident_hash(self, value):
+
+        try:
+            self._id, self.metadata['version'] = value.split('@')
+        except ValueError:
+            raise ValueError("ident_hash requires a version", value)
 
     def get_uri(self, system, default=None):
         try:
@@ -436,7 +460,6 @@ class Document(object):
 
     def __init__(self, id, data, metadata=None, resources=None,
                  reference_resolver=None):
-        self.id = id
         self._xml = None
         if hasattr(data, 'read'):
             self.content = utf8(data.read())
@@ -445,6 +468,7 @@ class Document(object):
         self._references = _parse_references(self._xml)
         self.metadata = utf8(metadata or {})
         self.resources = resources or []
+        self.id = id
 
     def _content__get(self):
         """Produce the content from the data.
@@ -467,6 +491,22 @@ class Document(object):
                        _content__get.__doc__)
 
     @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+
+        if value and '@' in value:
+            self._id, self.metadata['version'] = value.split('@')
+        else:
+            self._id = value
+
+    @id.deleter
+    def id(self, value):
+        del self._id
+
+    @property
     def ident_hash(self):
         if self.id is not None:
             args = [self.id]
@@ -477,6 +517,14 @@ class Document(object):
         else:
             value = None
         return value
+
+    @ident_hash.setter
+    def ident_hash(self, value):
+
+        try:
+            self._id, self.metadata['version'] = value.split('@')
+        except ValueError:
+            raise ValueError("ident_hash requires a version", value)
 
     def get_uri(self, system, default=None):
         try:

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -84,7 +84,7 @@
       <h1 data-type="document-title" itemprop="name">Chapter One</h1>
       <span data-type="binding" data-value="translucent"/>    </div>
 
-   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -138,16 +138,16 @@
    
     
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_13436">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_13436">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_84744">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_84744">If you finish the book, there will be cake.</p>
   
   
   </div></div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter Two</h1>
       <span data-type="binding" data-value="translucent"/>    </div>
 
-   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -201,9 +201,9 @@
    
     
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_76378">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_76378">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_25507">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_25507">If you finish the book, there will be cake.</p>
   
   
   </div></div></div><div data-type="unit"><div data-type="metadata">
@@ -214,7 +214,7 @@
       <h1 data-type="document-title" itemprop="name">Chapter Three</h1>
       <span data-type="binding" data-value="translucent"/>    </div>
 
-   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -268,9 +268,9 @@
    
     
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_49544">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_49544">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_44949">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_44949">If you finish the book, there will be cake.</p>
   
   
   </div></div></div></body>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -84,7 +84,7 @@
       <h1 data-type="document-title" itemprop="name">Chapter One</h1>
       <span data-type="binding" data-value="translucent"/>    </div>
 
-   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -138,16 +138,16 @@
    
     
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_17611">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_17611">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_74606">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_74606">If you finish the book, there will be cake.</p>
   
   
   </div></div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter Two</h1>
       <span data-type="binding" data-value="translucent"/>    </div>
 
-   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -201,9 +201,9 @@
    
     
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_8271">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_8271">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_33432">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_33432">If you finish the book, there will be cake.</p>
   
   
   </div></div></div><div data-type="unit"><div data-type="metadata">
@@ -214,7 +214,7 @@
       <h1 data-type="document-title" itemprop="name">Chapter Three</h1>
       <span data-type="binding" data-value="translucent"/>    </div>
 
-   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667@3"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -268,9 +268,9 @@
    
     
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_15455">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667@3">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_15455">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667@3_64937">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_64937">If you finish the book, there will be cake.</p>
   
   
   </div></div></div></body>

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -17,6 +17,7 @@
   </head>
   <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
+      <span data-type="cnx-archive-uri" data-value="27cf60e4-bd82-418a-a7bb-a939c40f8f50@1.1"></span>
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
 
       <div class="authors">
@@ -107,7 +108,7 @@
 </ul>
 <p id="auto_apple_12345"><a href="#chocolate">Link to chocolate</a>.</p>
   </div>
-<div data-type="chapter">
+<div data-type="chapter" id="c21a1764-f659-42b0-991e-bdf5784819a1">
 <h1 data-type="document-title">Citrus</h1>
 <div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
@@ -218,7 +219,7 @@
 </ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_99740"></img><p id="auto_chocolate_58915">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
 <p>Click <a href="#auto_chocolate_1">here</a> to see more notes.</p>
   </div>
-<div data-type="composite-page" id="extra">
+<div data-type="composite-page" data-uuid-key="extra">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -89,7 +89,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
 
         from ..adapters import adapt_package
         binder = adapt_package(package)
-        self.assertEqual(binder.id, '9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6')
+        self.assertEqual(binder.id, '9b0903d2-13c4-4ebe-9ffe-1ee79db28482')
         self.assertEqual(binder.ident_hash,
                          '9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6')
         self.assertEqual(len(binder.resources), 1)

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -845,13 +845,13 @@ class HTMLAdaptationTestCase(unittest.TestCase):
 
         self.assertIn('<p id="1">Content moved from another page.</p>',
                       extra.content)
-        self.assertIn('Click <a href="/contents/extra#1">here</a>',
+        self.assertIn('Click <a href="/contents/9f7dce40-0de7-5a29-a416-a9cf8eedf4d4#1">here</a>',
                       chocolate.content)
         self.assertIn('<p id="summary0"> Pretend move of lemon summary</p>',
                       extra.content)
         self.assertIn('<p id="summary1"> Pretend move of chocolate summary</p>',
                       extra.content)
-        self.assertIn('<p id="myid">Be sure to read the <a href="/contents/extra#summary0">Summary for lemon</a></p>', lemon.content)
+        self.assertIn('<p id="myid">Be sure to read the <a href="/contents/9f7dce40-0de7-5a29-a416-a9cf8eedf4d4#summary0">Summary for lemon</a></p>', lemon.content)
 
     def test_fix_generated_ids_links_without_version(self):
         from ..adapters import adapt_single_html

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -182,7 +182,8 @@ class CollateTestCase(BaseModelTestCase):
         binder = self.make_binder(
             '8d75ea29',
             metadata={'version': '3', 'title': 'Book One',
-                      'license_url': 'http://my.license'},
+                      'license_url': 'http://my.license',
+                      'cnx-archive-uri': 'bad183c3-8776-4a6d-bb02-3b11e0c26aaf'},
             nodes=[
                 self.make_document(
                     id="e78d4f90",
@@ -246,7 +247,7 @@ class CollateTestCase(BaseModelTestCase):
 
         # Check for the appended composite document
         self.assertEqual(len(collated_binder), 3)
-        self.assertEqual(collated_binder[2].id, None)
+        self.assertEqual(collated_binder[2].id, 'a9428a6c-5d31-5425-8335-8a2e780651e0')
         self.assertEqual(collated_binder[2].metadata['title'],
                          'Composite One')
 

--- a/cnxepub/tests/test_models.py
+++ b/cnxepub/tests/test_models.py
@@ -63,6 +63,16 @@ class ModelAttributesTestCase(BaseModelTestCase):
             binder.ident_hash = '67e4ag'
             self.assertContains(caughtexception, 'requires version')
 
+        del binder.id
+        with self.assertRaises(AttributeError) as caughtexception:
+            _ = binder.id
+            self.assertContains(caughtexception, 'object has no attribute')
+
+        binder.id = '456@2'
+        self.assertEqual(binder.id, '456')
+        self.assertEqual(binder.ident_hash, '456@2')
+        self.assertEqual(binder.metadata['version'], '2')
+
     def test_document_attribs(self):
         document = self.make_document('8d75ea29@3')
 
@@ -78,6 +88,16 @@ class ModelAttributesTestCase(BaseModelTestCase):
         with self.assertRaises(ValueError) as caughtexception:
             document.ident_hash = '67e4ag'
             self.assertContains(caughtexception, 'requires version')
+
+        del document.id
+        with self.assertRaises(AttributeError) as caughtexception:
+            _ = document.id
+            self.assertContains(caughtexception, 'object has no attribute')
+
+        document.id = '456@2'
+        self.assertEqual(document.id, '456')
+        self.assertEqual(document.ident_hash, '456@2')
+        self.assertEqual(document.metadata['version'], '2')
 
 
 class PrivateUtilitiesTestCase(unittest.TestCase):

--- a/cnxepub/tests/test_models.py
+++ b/cnxepub/tests/test_models.py
@@ -14,8 +14,6 @@ try:
 except ImportError:
     import mock
 
-from lxml import etree
-
 
 here = os.path.abspath(os.path.dirname(__file__))
 TEST_DATA_DIR = os.path.join(here, 'data')
@@ -47,9 +45,44 @@ class BaseModelTestCase(unittest.TestCase):
         return Resource(*args, **kwargs)
 
 
+class ModelAttributesTestCase(BaseModelTestCase):
+
+    def test_binder_attribs(self):
+        binder = self.make_binder('8d75ea29@3')
+
+        self.assertEqual(binder.id, '8d75ea29')
+        self.assertEqual(binder.ident_hash, '8d75ea29@3')
+        self.assertEqual(binder.metadata['version'], '3')
+
+        binder.ident_hash = '67e4ag@4.5'
+        self.assertEqual(binder.id, '67e4ag')
+        self.assertEqual(binder.ident_hash, '67e4ag@4.5')
+        self.assertEqual(binder.metadata['version'], '4.5')
+
+        with self.assertRaises(ValueError) as caughtexception:
+            binder.ident_hash = '67e4ag'
+            self.assertContains(caughtexception, 'requires version')
+
+    def test_document_attribs(self):
+        document = self.make_document('8d75ea29@3')
+
+        self.assertEqual(document.id, '8d75ea29')
+        self.assertEqual(document.ident_hash, '8d75ea29@3')
+        self.assertEqual(document.metadata['version'], '3')
+
+        document.ident_hash = '67e4ag@4.5'
+        self.assertEqual(document.id, '67e4ag')
+        self.assertEqual(document.ident_hash, '67e4ag@4.5')
+        self.assertEqual(document.metadata['version'], '4.5')
+
+        with self.assertRaises(ValueError) as caughtexception:
+            document.ident_hash = '67e4ag'
+            self.assertContains(caughtexception, 'requires version')
+
+
 class PrivateUtilitiesTestCase(unittest.TestCase):
 
-    def test_sanatize_xml(self):
+    def test_sanitize_xml(self):
         from ..models import _sanitize_xml as target
         xml_namespaces = ' '.join([
             'xmlns:bib="http://bibtexml.sf.net/"',
@@ -117,7 +150,7 @@ class TreeUtilityTestCase(BaseModelTestCase):
                                     metadata={'version': '2',
                                               'title': "Document Three"})])]),
                 self.make_binder(
-                    None,
+                    '4e5390a5@2',
                     metadata={'title': "Part Three"},
                     nodes=[
                         self.make_binder(
@@ -162,7 +195,7 @@ class TreeUtilityTestCase(BaseModelTestCase):
                            'title': 'Document Three'}],
                       'title': 'Chapter Three'}],
                  'title': 'Part Two'},
-                {'id': 'subcol',
+                {'id': '4e5390a5@2',
                  'shortId': None,
                  'contents': [
                      {'id': 'subcol',


### PR DESCRIPTION
This is the last step for stabilzing the assigned uuids for composite documents - we removed assigning uuids from rulesets/easybake in order to do it here when publishing. Not yet complete, needs testing in the publish-new-version case, to verify that uuids stay constant, and the versions bump appropriately.