### PR TITLE
Composite chapters

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -230,18 +230,20 @@ def _node_to_model(tree_or_item, package, parent=None,
     if 'contents' in tree_or_item:
         # It is a binder.
         tree = tree_or_item
+        metadata = package.metadata.copy()
         if tree['id'] == lucent_id:
-            binder = TranslucentBinder(metadata={'title': tree['title']})
+            metadata['title'] = tree['title']
+            binder = TranslucentBinder(metadata)
         else:
             try:
                 package_item = package.grab_by_name(tree['id'])
                 binder = BinderItem(package_item, package)
             except KeyError:  # Translucent w/ id
-                binder = Binder(tree['id'],
-                                metadata={
-                                   'title': tree['title'],
-                                   'cnx-archive-uri': tree['id'],
-                                   'cnx-archive-shortid': tree['shortId']})
+                metadata.update({
+                   'title': tree['title'],
+                   'cnx-archive-uri': tree['id'],
+                   'cnx-archive-shortid': tree['shortId']})
+                binder = Binder(tree['id'], metadata=metadata)
         for item in tree['contents']:
             node = _node_to_model(item, package, parent=binder,
                                   lucent_id=lucent_id)
@@ -463,7 +465,8 @@ def _adapt_single_html_tree(parent, elem, nav_tree, id_map=None, depth=0):
 
         if data_type in ('unit', 'chapter', 'composite-chapter',
                          'page', 'composite-page'):
-            metadata = parse_metadata(child)
+            metadata = parse_metadata(
+                    child.xpath('./*[@data-type="metadata"]')[0])
             # Handle id and uuid from metadata
             id_ = metadata.get('cnx-archive-uri') or child.attrib.get('id')
             if not id_:

--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -233,7 +233,7 @@ def _node_to_model(tree_or_item, package, parent=None,
         metadata = package.metadata.copy()
         if tree['id'] == lucent_id:
             metadata['title'] = tree['title']
-            binder = TranslucentBinder(metadata)
+            binder = TranslucentBinder(metadata=metadata)
         else:
             try:
                 package_item = package.grab_by_name(tree['id'])

--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -516,8 +516,10 @@ def _adapt_single_html_tree(parent, elem, nav_tree, id_map=None, depth=0):
             parent.append(document)
 
             fix_generated_ids(document, id_map)  # also populates id_map
-        else:  # Fall through - child is not a defined type FIXME warn?
+        elif data_type in ['metadata', None]:
             pass
+        else:  # Fall through - child is not a defined type
+            raise AdaptationError
 
     # Assign title overrides
     if len(parent) != len(title_overrides):

--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -131,8 +131,9 @@ def model_to_tree(model, title=None, lucent_id=TRANSLUCENT_BINDER_ID):
     id = model.ident_hash
     if id is None and isinstance(model, TranslucentBinder):
         id = lucent_id
-    shortid = model.metadata.get('shortId')
-    title = title is not None and title or model.metadata.get('title')
+    md = model.metadata
+    shortid = md.get('shortId', md.get('cnx-archive-shortid'))
+    title = title is not None and title or md.get('title')
     tree = {'id': id, 'title': title, 'shortId': shortid}
     if hasattr(model, '__iter__'):
         contents = tree['contents'] = []

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -75,14 +75,26 @@
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
+   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
   <div data-type="unit"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Part One</h1><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter One</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
@@ -145,7 +157,13 @@
   
   </div></div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter Two</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
@@ -208,11 +226,23 @@
   
   </div></div></div><div data-type="unit"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Part Two</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Part Two</h1><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter Three</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -75,14 +75,26 @@
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
+   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
   <div data-type="unit"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Part One</h1><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter One</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
@@ -145,7 +157,13 @@
   
   </div></div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter Two</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
@@ -208,11 +226,23 @@
   
   </div></div></div><div data-type="unit"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Part Two</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Part Two</h1><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Chapter Three</h1>
-      <span data-type="binding" data-value="translucent"/>    </div>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -57,6 +57,15 @@
 
    <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit">
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Fruity</h1>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+        </p>
+      </div>
+    </div>
 <h1 data-type="document-title">Fruity</h1>
 <div data-type="page" id="apple">
 <div data-type="metadata">
@@ -110,6 +119,15 @@
   </div>
 <div data-type="chapter" id="c21a1764-f659-42b0-991e-bdf5784819a1">
 <h1 data-type="document-title">Citrus</h1>
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+        </p>
+      </div>
+    </div>
 <div data-type="page" id="lemon" class="fruity">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -51,6 +51,10 @@
         data-type='document-title'
         itemprop='name'
       >Desserts</h1>
+      <span
+        data-type='cnx-archive-uri'
+        data-value='00000000-0000-0000-0000-000000000000'
+      ></span>
       <div
         class='permissions'
       >
@@ -84,7 +88,7 @@
       <ol>
         <li
           cnx-archive-shortid='frt'
-          cnx-archive-uri='Fruity'
+          cnx-archive-uri='ec84e75d-9973-41f1-ab9d-1a3ebaef87e2'
         >
           <span>Fruity</span>
           <ol>
@@ -142,7 +146,7 @@
     </nav>
     <div
       data-type='unit'
-      id='Fruity'
+      id='ec84e75d-9973-41f1-ab9d-1a3ebaef87e2'
     >
       <div
         data-type='metadata'
@@ -153,12 +157,26 @@
         >Fruity</h1>
         <span
           data-type='cnx-archive-uri'
-          data-value='Fruity'
+          data-value='ec84e75d-9973-41f1-ab9d-1a3ebaef87e2'
         ></span>
         <span
           data-type='cnx-archive-shortid'
           data-value='frt'
         ></span>
+        <div
+          class='permissions'
+        >
+          <p
+            class='license'
+          >
+          Licensed:
+            <a
+              data-type='license'
+              href='http://creativecommons.org/licenses/by/4.0/'
+              itemprop='dc:license,lrmi:useRightsURL'
+            >CC-BY 4.0</a>
+          </p>
+        </div>
       </div>
       <h1
         data-type='document-title'

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -83,6 +83,7 @@
     >
       <ol>
         <li
+          cnx-archive-shortid='frt'
           cnx-archive-uri='Fruity'
         >
           <span>Fruity</span>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -52,6 +52,10 @@
         data-type='document-title'
         itemprop='name'
       >Desserts</h1>
+      <span
+        data-type='cnx-archive-uri'
+        data-value='00000000-0000-0000-0000-000000000000'
+      ></span>
       <div
         class='permissions'
       >
@@ -85,7 +89,7 @@
       <ol>
         <li
           cnx-archive-shortid='frt'
-          cnx-archive-uri='Fruity'
+          cnx-archive-uri='ec84e75d-9973-41f1-ab9d-1a3ebaef87e2'
         >
           <span>Fruity</span>
           <ol>
@@ -143,7 +147,7 @@
     </nav>
     <div
       data-type='unit'
-      id='Fruity'
+      id='ec84e75d-9973-41f1-ab9d-1a3ebaef87e2'
     >
       <div
         data-type='metadata'
@@ -154,12 +158,26 @@
         >Fruity</h1>
         <span
           data-type='cnx-archive-uri'
-          data-value='Fruity'
+          data-value='ec84e75d-9973-41f1-ab9d-1a3ebaef87e2'
         ></span>
         <span
           data-type='cnx-archive-shortid'
           data-value='frt'
         ></span>
+        <div
+          class='permissions'
+        >
+          <p
+            class='license'
+          >
+          Licensed:
+            <a
+              data-type='license'
+              href='http://creativecommons.org/licenses/by/4.0/'
+              itemprop='dc:license,lrmi:useRightsURL'
+            >CC-BY 4.0</a>
+          </p>
+        </div>
       </div>
       <h1
         data-type='document-title'

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -84,6 +84,7 @@
     >
       <ol>
         <li
+          cnx-archive-shortid='frt'
           cnx-archive-uri='Fruity'
         >
           <span>Fruity</span>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -18,6 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
       <div class="permissions">
         <p class="license">
@@ -30,11 +31,17 @@
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
-  <div data-type="unit" id="Fruity"><div data-type="metadata">
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
-      <span data-type="cnx-archive-uri" data-value="Fruity"/>
-      <span data-type="cnx-archive-shortid" data-value="frt"/>    </div>
+      <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
+      <span data-type="cnx-archive-shortid" data-value="frt"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -18,6 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
       <div class="permissions">
         <p class="license">
@@ -30,11 +31,17 @@
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
-  <div data-type="unit" id="Fruity"><div data-type="metadata">
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
-      <span data-type="cnx-archive-uri" data-value="Fruity"/>
-      <span data-type="cnx-archive-shortid" data-value="frt"/>    </div>
+      <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
+      <span data-type="cnx-archive-shortid" data-value="frt"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>

--- a/cnxepub/tests/data/desserts-single-page-bad-type.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad-type.xhtml
@@ -1,0 +1,295 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Desserts</title>
+    <meta content="" data-type="language" itemprop="inLanguage"/>
+
+    
+    <meta content="MathML" itemprop="accessibilityFeature"/>
+    <meta content="LaTeX" itemprop="accessibilityFeature"/>
+    <meta content="alternativeText" itemprop="accessibilityFeature"/>
+    <meta content="captions" itemprop="accessibilityFeature"/>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+
+
+    <meta content="" itemprop="dateCreated"/>
+    <meta content="" itemprop="dateModified"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
+
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="cover.png">cover.png</a></li>        </ul>
+      </div>    </div>
+
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Fruity</h1>
+      <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
+      <span data-type="cnx-archive-shortid" data-value="frt"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>    </div>
+
+   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Apple</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+
+   <h1>Apple Desserts</h1>
+
+<p id="auto_apple_74606"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
+
+<ul><li id="auto_apple_13436">Apple Crumble,</li>
+    <li>Apfelstrudel,</li>
+    <li id="auto_apple_17611">Caramel Apple,</li>
+    <li>Apple Pie,</li>
+    <li>Apple sauce...</li>
+</ul>
+  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
+      </div>    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_8271">Yum! <img id="auto_lemon_33432" src="/resources/1x1.jpg"/></p>
+
+<div data-type="exercise" id="auto_lemon_15455">
+    <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
+</div>
+
+
+
+<div data-type="exercise" id="auto_lemon_64937">
+    <p id="auto_lemon_99740">
+    <a href="#ost/api/ex/nosuchtag">[link]</a>
+    </p>
+</div>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div><div data-type="chapter"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+
+   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Lemon</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
+      </div>    </div>
+
+   
+<h1>Lemon Desserts</h1>
+
+<p id="auto_lemon_58915">Yum! <img id="auto_lemon_61898" src="/resources/1x1.jpg"/></p>
+
+<div data-type="exercise" id="auto_lemon_85405">
+    <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
+</div>
+
+
+
+<div data-type="exercise" id="auto_lemon_49756">
+    <p id="auto_lemon_27519">
+    <a href="#ost/api/ex/nosuchtag">[link]</a>
+    </p>
+</div>
+
+<ul><li>Lemon &amp; Lime Crush,</li>
+    <li>Lemon Drizzle Loaf,</li>
+    <li>Lemon Cheesecake,</li>
+    <li>Raspberry &amp; Lemon Polenta Cake...</li>
+</ul>
+
+
+  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      <div data-type="resources" style="display: none">
+        <ul>
+<li><a href="1x1.jpg">small.jpg</a></li>        </ul>
+      </div>    </div>
+
+   <h1>Chocolate Desserts</h1>
+
+<p id="auto_chocolate_12302"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
+
+<div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
+    <li>Hot Mocha Puddings,</li>
+    <li>Chocolate and Banana French Toast,</li>
+    <li>Chocolate Truffles...</li>
+</ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+  </div><div data-type="composite-page" id="extra"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      <div class="description" data-type="description" itemprop="description">
+        <p>summary</p>
+      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+
+   <h1>Extra Stuff</h1>
+
+<p id="auto_extra_51093">This is a composite page.</p>
+
+<p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+  </div>
+  <div data-type="bad-chapter"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">BAD Citrus</h1>
+      <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+
+   <h1 data-type="document-title">BAD Citrus</h1>
+  </div>
+  </div>
+  </body>
+</html>

--- a/cnxepub/tests/data/desserts-single-page-bad.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad.xhtml
@@ -74,6 +74,15 @@
    </nav>
   <div data-type="unit">
 <h1 data-type="document-title">Fruity</h1>
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Fruity</h1>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+        </p>
+      </div>
+    </div>
 <div data-type="page" id="apple">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
@@ -184,6 +193,15 @@
   </div>
 <div data-type="chapter">
 <h1 data-type="document-title">Citrus</h1>
+    <div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Fruity</h1>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a href="" itemprop="dc:license,lrmi:useRightsURL" data-type="license"></a>
+        </p>
+      </div>
+    </div>
 <div data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -30,7 +30,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="Fruity"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="Fruity"/>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -18,6 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
       <div class="permissions">
         <p class="license">
@@ -30,11 +31,17 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
-  <div data-type="unit" id="Fruity"><div data-type="metadata">
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
-      <span data-type="cnx-archive-uri" data-value="Fruity"/>
-      <span data-type="cnx-archive-shortid" data-value="frt"/>    </div>
+      <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
+      <span data-type="cnx-archive-shortid" data-value="frt"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>    </div>
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>

--- a/cnxepub/tests/data/desserts-single-page.html
+++ b/cnxepub/tests/data/desserts-single-page.html
@@ -18,6 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
 
       <div class="permissions">
         <p class="license">
@@ -30,11 +31,18 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span cnx-archive-uri="Fruity">Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
-  <div data-type="unit" id="Fruity"><div data-type="metadata">
+   <nav id="toc"><ol><li><span cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2">Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
-      <span data-type="cnx-archive-uri" data-value="Fruity"></span>
-      <span data-type="cnx-archive-shortid" data-value="frt"></span>    </div>
+      <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"></span>
+      <span data-type="cnx-archive-shortid" data-value="frt"></span>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      </div>
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -31,11 +31,18 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="Fruity"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
-  <div data-type="unit" id="Fruity"><div data-type="metadata">
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
-      <span data-type="cnx-archive-uri" data-value="Fruity"/>
-      <span data-type="cnx-archive-shortid" data-value="frt"/>    </div>
+      <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
+      <span data-type="cnx-archive-shortid" data-value="frt"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
+      </div>
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
@@ -128,6 +135,12 @@
   </div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
       <span data-type="binding" data-value="translucent"/>
+      <div class="permissions">
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+        </p>
+      </div>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -17,8 +17,8 @@
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
-      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
       <div class="permissions">
         <p class="license">
@@ -31,7 +31,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
@@ -41,8 +41,7 @@
           Licensed:
           <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
-      </div>
-      </div>
+      </div>    </div>
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
@@ -135,12 +134,6 @@
   </div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
       <span data-type="binding" data-value="translucent"/>
-      <div class="permissions">
-        <p class="license">
-          Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
-        </p>
-      </div>
       <div class="authors">
         By:
 <span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -17,6 +17,7 @@
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
 
       <div class="permissions">

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -713,8 +713,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                                      u'<span>&#12524;&#12514;&#12531;</span>',
                             },
                         {
-                            'id': 'subcol',
-                            'shortId': None,
+                            'id': '368a406a-11aa-4734-a0e3-6b9d649fd88f',
+                            'shortId': u'NopAahGq',
                             'title': '<span>Chapter</span> <span>2</span> '
                                      '<span>citrus</span>',
                             'contents': [

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -57,7 +57,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
         expected_tree = {
             'id': '9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6',
             'title': 'Book of Infinity',
-            'shortId': None,
+            'shortId': u'mwkD0hPE@1.6',
             'contents': [
                 {'id': 'subcol',
                  'shortId': None,
@@ -65,7 +65,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
                  'contents': [
                      {'contents': [
                          {'id': 'e78d4f90-e078-49d2-beac-e95e8be70667@3',
-                          'shortId': None, 'title': 'Document One'}],
+                          'shortId': u'541PkOB4@3', 'title': 'Document One'}],
                       'id': 'subcol',
                       'shortId': None,
                       'title': 'Chapter One'},
@@ -73,7 +73,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
                       'shortId': None,
                       'title': 'Chapter Two',
                       'contents': [{'id': 'e78d4f90-e078-49d2-beac-e95e8be70667@3',
-                                    'shortId': None, 'title': 'Document One (again)'}],
+                                    'shortId': u'541PkOB4@3', 'title': 'Document One (again)'}],
                       }]},
                 {'id': 'subcol',
                  'shortId': None,
@@ -84,7 +84,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
                       'title': 'Chapter Three',
                       'contents': [
                           {'id': 'e78d4f90-e078-49d2-beac-e95e8be70667@3',
-                            'shortId': None, 'title': 'Document One (...and again)'}]
+                            'shortId': u'541PkOB4@3', 'title': 'Document One (...and again)'}]
                       }]}]}
 
         from ..adapters import adapt_package
@@ -692,58 +692,57 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('Desserts', desserts.metadata['title'])
 
         self.assertEqual({
-            'id': 'book',
             'shortId': None,
-            'title': 'Desserts',
+            'id': '00000000-0000-0000-0000-000000000000',
             'contents': [
                 {
-                    'id': 'Fruity',
                     'shortId': 'frt',
-                    'title': 'Fruity',
+                    'id': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2',
                     'contents': [
                         {
+                            'shortId': None,
                             'id': 'apple',
-                            'shortId': None,
-                            'title': 'Apple',
-                            },
+                            'title': 'Apple'
+                        },
                         {
+                            'shortId': None,
                             'id': 'lemon',
-                            'shortId': None,
-                            'title': u'<span>1.1</span> <span>|</span> '
-                                     u'<span>&#12524;&#12514;&#12531;</span>',
-                            },
+                            'title': '<span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span>'
+                        },
+
                         {
-                            'id': '368a406a-11aa-4734-a0e3-6b9d649fd88f',
-                            'shortId': u'NopAahGq',
-                            'title': '<span>Chapter</span> <span>2</span> '
-                                     '<span>citrus</span>',
+                            "shortId": "sfE7YYyV",
+                            "id": "b1f13b61-8c95-5fbe-9112-46400b6dc8de",
                             'contents': [
                                 {
-                                    'id': 'lemon',
                                     'shortId': None,
-                                    'title': 'Lemon',
-                                    },
-                                ],
-                            },
-                        ],
-                    },
+                                    'id': 'lemon',
+                                    'title': 'Lemon'
+                                }
+                            ],
+                            'title': '<span>Chapter</span> <span>2</span> <span>citrus</span>'
+                        }
+                    ],
+                    'title': 'Fruity'
+                },
                 {
+                    'shortId': None,
                     'id': 'chocolate',
-                    'shortId': None,
-                    'title': u'チョコレート',
-                    },
+                    'title': u'\u30c1\u30e7\u30b3\u30ec\u30fc\u30c8'
+                },
                 {
-                    'id': 'extra',
                     'shortId': None,
-                    'title': 'Extra Stuff',
-                    },
-                ],
+                    'id': 'extra',
+                    'title': 'Extra Stuff'
+                }
+            ],
+            'title': 'Desserts'
             }, model_to_tree(desserts))
 
         fruity = desserts[0]
         self.assertEqual('Binder', fruity.__class__.__name__)
         self.assertEqual('Fruity', fruity.metadata['title'])
-        self.assertEqual('Fruity', fruity.metadata['id'])
+        self.assertEqual('ec84e75d-9973-41f1-ab9d-1a3ebaef87e2', fruity.metadata['id'])
         self.assertEqual('frt', fruity.metadata['shortId'])
         self.assertEqual('Fruity', desserts.get_title_for_node(fruity))
 
@@ -778,7 +777,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                          fruity.get_title_for_node(lemon))
 
         citrus = fruity[2]
-        self.assertEqual('TranslucentBinder', citrus.__class__.__name__)
+        self.assertEqual('Binder', citrus.__class__.__name__)
         self.assertEqual(citrus.metadata['title'], 'Citrus')
 
         self.assertEqual(lemon.metadata, citrus[0].metadata)

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -828,6 +828,19 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         with self.assertRaises(AdaptationError) as caught_exception:
             desserts = adapt_single_html(html)
 
+    def test_unknown_data_type(self):
+        """Throw error if unknown data-type in HTML"""
+        page_path = os.path.join(TEST_DATA_DIR, 'desserts-single-page-bad-type.xhtml')
+        from ..adapters import adapt_single_html
+        from ..models import model_to_tree
+
+        with open(page_path, 'r') as f:
+            html = f.read()
+
+        from ..adapters import AdaptationError
+        with self.assertRaises(AdaptationError) as caught_exception:
+            desserts = adapt_single_html(html)
+
     def test_fix_generated_ids_in_composite_page(self):
         from ..adapters import adapt_single_html
 

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -46,53 +46,47 @@ class ReconstituteTestCase(unittest.TestCase):
         self.assertEqual('Desserts', desserts.metadata['title'])
 
         self.assertEqual({
-            'id': 'book',
             'shortId': None,
-            'title': 'Desserts',
-            'contents': [
-                {
-                    'id': 'Fruity',
-                    'shortId': 'frt',
-                    'title': 'Fruity',
-                    'contents': [
-                        {
-                            'id': 'apple',
-                            'shortId': None,
-                            'title': 'Apple',
-                            },
-                        {
-                            'id': 'lemon',
-                            'shortId': None,
-                            'title': '<span>1.1</span> <span>|</span> '
-                                     '<span>&#12524;&#12514;&#12531;</span>',
-                            },
-                        {
-                            'id': 'subcol',
-                            'shortId': None,
-                            'title': '<span>Chapter</span> <span>2</span> '
-                                     '<span>citrus</span>',
-                            'contents': [
-                                {
-                                    'id': 'lemon',
-                                    'shortId': None,
-                                    'title': 'Lemon',
-                                    },
-                                ],
-                            },
+            'id': '00000000-0000-0000-0000-000000000000',
+            'contents': [{
+                'shortId': 'frt',
+                'id': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2',
+                'contents': [{
+                    'shortId': None,
+                    'id': 'apple',
+                    'title': 'Apple'
+                    },
+                    {
+                    'shortId': None,
+                    'id': 'lemon',
+                    'title': '<span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span>'
+                    },
+                    {
+                    'shortId': 'sfE7YYyV',
+                    'id': 'b1f13b61-8c95-5fbe-9112-46400b6dc8de',
+                    'contents': [{
+                        'shortId': None,
+                        'id': 'lemon',
+                        'title': 'Lemon'
+                        }
                         ],
+                    'title': '<span>Chapter</span> <span>2</span> <span>citrus</span>'
+                    }
+                    ],
+                'title': 'Fruity'
                     },
-                {
-                    'id': 'chocolate',
-                    'shortId': None,
-                    'title': u'チョコレート',
+                    {
+                        'shortId': None,
+                        'id': 'chocolate',
+                        'title': u'\u30c1\u30e7\u30b3\u30ec\u30fc\u30c8'
                     },
-                {
-                    'id': 'extra',
-                    'shortId': None,
-                    'title': 'Extra Stuff',
-                    },
-                ],
-            }, model_to_tree(desserts))
+                    {
+                        'shortId': None,
+                        'id': 'extra',
+                        'title': 'Extra Stuff'
+                    }
+                    ],
+                'title': 'Desserts'}, model_to_tree(desserts))
 
         base_metadata = {
             u'publishers': [],
@@ -145,7 +139,7 @@ class ReconstituteTestCase(unittest.TestCase):
         self.assertEqual(metadata, lemon_metadata)
 
         citrus = fruity[2]
-        self.assertEqual('TranslucentBinder', citrus.__class__.__name__)
+        self.assertEqual('Binder', citrus.__class__.__name__)
         self.assertEqual(citrus.metadata['title'], 'Citrus')
 
         self.assertEqual(lemon.metadata, citrus[0].metadata)

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -676,10 +676,13 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             self.apple.metadata['title'],
             u'<span>1.1</span> <span>|</span> <span>レモン</span>',
             '<span>Chapter</span> <span>2</span> <span>citrus</span>']
-        self.fruity = Binder('Fruity', [self.apple, self.lemon, self.citrus],
+        self.fruity = Binder('ec84e75d-9973-41f1-ab9d-1a3ebaef87e2', [self.apple, self.lemon, self.citrus],
                              metadata={'title': 'Fruity',
-                                       'cnx-archive-uri': 'Fruity',
-                                       'cnx-archive-shortid': 'frt'},
+                                       'cnx-archive-uri': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2',
+                                       'cnx-archive-shortid': 'frt',
+                                       'license_text': 'CC-By 4.0',
+                                       'license_url': 'http://creativecommons.org/licenses/by/4.0/',
+                                       },
                              title_overrides=title_overrides)
 
         metadata = self.base_metadata.copy()
@@ -701,7 +704,8 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             'Desserts', [self.fruity, self.chocolate, self.extra],
             metadata={'title': 'Desserts',
                       'license_url': 'http://creativecommons.org/licenses/by/4.0/',
-                      'license_text': 'CC-By 4.0'},
+                      'license_text': 'CC-By 4.0',
+                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000'},
             resources=[cover_png])
 
     def test_binder(self):


### PR DESCRIPTION
This handles a new type coming from baked HTML: composite-chapter. It also unifies metadata handling. Note that single-html ingestion still requires that the nav toc match the document. The new, stricter requirement, is that metadata must exist as a `[data-type=metadata]` direct child of each object (chapter or page, of whatever type)