### PR TITLE
correctly handle chapter metadata after baking

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -491,9 +491,11 @@ def _adapt_single_html_tree(parent, elem, nav_tree, id_map=None, depth=0):
                         child.xpath('*[@data-type="document-title"]',
                                     namespaces=HTML_DOCUMENT_NAMESPACES)[0]
                         ).text_content().strip()
-            binder = Binder(id_, metadata={'title': title,
-                                           'id': id_,
-                                           'shortId': shortid})
+            metadata.update({'title': title,
+                             'id': id_,
+                             'shortId': shortid,
+                             'type': data_type})
+            binder = Binder(id_, metadata=metadata)
             # Recurse
             _adapt_single_html_tree(binder, child,
                                     nav_tree['contents'].pop(0),

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -73,7 +73,7 @@ class DocumentSummaryFormatter(object):
 
     def __bytes__(self):
         # try to make sure summary is wrapped in a tag
-        summary = self.document.metadata['summary']
+        summary = self.document.metadata.get('summary','')
         try:
             etree.fromstring(summary)
             html = '{}'.format(summary)

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -73,7 +73,7 @@ class DocumentSummaryFormatter(object):
 
     def __bytes__(self):
         # try to make sure summary is wrapped in a tag
-        summary = self.document.metadata.get('summary','')
+        summary = self.document.metadata.get('summary', '')
         try:
             etree.fromstring(summary)
             html = '{}'.format(summary)


### PR DESCRIPTION
The metadata is being set in the baking, but mostly ignored in the model. This corrects that.