### PR TITLE
use HTML parsing for baking. Make html_parsers namespace agnostic

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -539,6 +539,7 @@ HTML_DOCUMENT = """\
       xmlns:mod="http://cnx.rice.edu/#moduleIds"
       xmlns:md="http://cnx.rice.edu/mdml"
       xmlns:c="http://cnx.rice.edu/cnxml"
+      lang="{{ metadata['language'] }}"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta content="None" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta content="None" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
+++ b/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head>
     <title>Book One</title>

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -1,4 +1,5 @@
 <html
+  lang='en'
   xmlns='http://www.w3.org/1999/xhtml'
 >
   <head
@@ -7,7 +8,7 @@
   >
     <title>Desserts</title>
     <meta
-      content=''
+      content='en'
       data-type='language'
       itemprop='inLanguage'
     ></meta>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -1,4 +1,5 @@
 <html
+  lang='en'
   xmlns='http://www.w3.org/1999/xhtml'
   xmlns:m='http://www.w3.org/1998/Math/MathML'
 >
@@ -8,7 +9,7 @@
   >
     <title>Desserts</title>
     <meta
-      content=''
+      content='en'
       data-type='language'
       itemprop='inLanguage'
     ></meta>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/desserts-single-page.html
+++ b/cnxepub/tests/data/desserts-single-page.html
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage">
+    <meta content="en" data-type="language" itemprop="inLanguage">
 
     
     <meta content="MathML" itemprop="accessibilityFeature">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/loose-pages/content/faux.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/faux.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head>
     <title>Loose Pages</title>

--- a/cnxepub/tests/data/loose-pages/content/fig-bush.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/fig-bush.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/data/loose-pages/content/mushroom-cloud.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/mushroom-cloud.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -191,7 +191,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'derived_from_title': u'Wild Grains and Warted Feet',
             u'cnx-archive-uri': None,
             u'cnx-archive-shortid': None,
-            u'language': None,
+            u'language': 'en',
             u'print_style': u'* print style *',
             }
         self.assertEqual(expected_metadata, document.metadata)
@@ -673,7 +673,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
         # 'version': 'draft',
-        u'language': None,
+        u'language': 'en',
         u'print_style': None,
         u'cnx-archive-uri': None,
         u'cnx-archive-shortid': None,

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -106,7 +106,7 @@ class ReconstituteTestCase(unittest.TestCase):
             u'license_text': u'CC-By 4.0',
             u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
             # 'version': 'draft',
-            u'language': None,
+            u'language': 'en',
             u'print_style': None,
             u'cnx-archive-uri': None,
             u'cnx-archive-shortid': None,

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -325,6 +325,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
             'license_url': 'http://creativecommons.org/licenses/by/4.0/',
             'summary': "<p>summary</p>",
             'version': 'draft',
+            'language': 'en'
             }
 
         # Build test document.
@@ -400,6 +401,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
         'license_url': 'http://creativecommons.org/licenses/by/4.0/',
         'summary': "<p>summary</p>",
         'version': 'draft',
+        'language': 'en'
         }
 
     maxDiff = None
@@ -480,6 +482,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
             'title': self.base_metadata['title'],
             'license_url': self.base_metadata['license_url'],
             'license_text': self.base_metadata['license_text'],
+            'language': self.base_metadata['language']
             })
 
         metadata = self.base_metadata.copy()
@@ -708,7 +711,8 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             metadata={'title': 'Desserts',
                       'license_url': 'http://creativecommons.org/licenses/by/4.0/',
                       'license_text': 'CC-By 4.0',
-                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000'},
+                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000',
+                      'language': 'en'},
             resources=[cover_png])
 
     def test_binder(self):

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -61,6 +61,6 @@ class HTMLParsingTestCase(unittest.TestCase):
             'derived_from_uri': 'http://example.org/contents/id@ver',
             'derived_from_title': 'Wild Grains and Warted Feet',
             'print_style': '* print style *',
-            'language': None,
+            'language': 'en',
             }
         self.assertEqual(metadata, expected_metadata)


### PR DESCRIPTION
The cnx-easybake cli tool uses the lxml.etree.HTMLParser. Internal cnx-epub baking did not: it used the XML parser. This came to light when sorting of keywords broke. This occured because the CSS selector used in recipes to designate the text to sort on (e.g. `dl > dt`) is converted internally by easybake to an xpath: `descendant-or-self::dl/dt` in order to create a sorting function to apply to each node when doing the sorted output. This would not match namespaced nodes. Ideally, this code should instead build another `cssselect2.Match` object, instead, just like the main processing loop in easybake. However, I would then need to create the equivalent to `etree.tostring`,  and other machinery. I started down that path, but believe I've ran into incomplete parts of `cssselect2`, and potentially just outright bugs. (the `query` function of an `ElementWrapper` claims to take `CompiledSelectors`, but errors when I try that) I will probably need to do that eventually, but this seemed a less invasive immediate fix.

Note that most of the xpath changes are removing unneeded namespace declarations. While this potentially changes the output in a mixed-xml environment (say some SVG or mathml) I don't think the results would be suprising.  There are a number of other simple alternative xpaths (with and w/o namespace, i.e. `xhtml:a | a`).

The only complicated cases are `license_url` and `license_text`. I in fact altered the behavior those two metadata methods to handle the now better understood business logic: any element should be licensed under its directly declared license, or that of one of its ancestors. I also added the special case of checking for a specific top level license for the whole book - this doesn't fall under the other rule if you happen to be holding the `html` or `head` nodes. Note that only this last case ends up needing the namespace alternatives.

