### PR TITLE
pass in recipe for baking

### DIFF
--- a/cnxepub/collation.py
+++ b/cnxepub/collation.py
@@ -51,7 +51,7 @@ def reconstitute(html):
     return adapt_single_html(xhtml)
 
 
-def collate(binder, ruleset="ruleset.css", includes=None):
+def collate(binder, ruleset=None, includes=None):
     """Given a ``Binder`` as ``binder``, collate the content into a new set
     of models.
     Returns the collated binder.
@@ -61,15 +61,11 @@ def collate(binder, ruleset="ruleset.css", includes=None):
     raw_html = io.BytesIO(bytes(html_formatter))
     collated_html = io.BytesIO()
 
-    try:
-        ruleset_resource = [r for r in binder.resources
-                            if r.filename == ruleset][0]
-    except IndexError:
+    if ruleset is None:
         # No ruleset found, so no cooking necessary.
         return binder
 
-    with ruleset_resource.open() as ruleset:
-        easybake(ruleset.read(), raw_html, collated_html)
+    easybake(ruleset, raw_html, collated_html)
 
     collated_html.seek(0)
     collated_binder = reconstitute(collated_html)

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -237,7 +237,8 @@ class CollateTestCase(BaseModelTestCase):
 
         with mock.patch('cnxepub.collation.easybake') as easybake:
             easybake.side_effect = mock_easybake
-            collated_binder = self.target(binder)
+            fake_ruleset = 'div::after {contents: "test"}'
+            collated_binder = self.target(binder, fake_ruleset)
 
         # Check for the appended composite document
         self.assertEqual(len(collated_binder), 3)
@@ -285,7 +286,7 @@ class CollateTestCase(BaseModelTestCase):
                               'license_url': 'http://my.license'})])
 
         # Append a ruleset to the binder.
-        ruleset = io.BytesIO(b"""\
+        ruleset_bytes = b"""\
 div[data-type='page'] > div[data-type='metadata'] {
   copy-to: eob-all
 }
@@ -330,12 +331,14 @@ nav#toc:pass(30)::after {
   content: pending(eob-toc);
   container: ol;
 }
-""")
-        resource = self.make_resource('ruleset', ruleset, 'text/css',
+"""
+        resource = self.make_resource('ruleset',
+                                      io.BytesIO(ruleset_bytes),
+                                      'text/css',
                                       filename='ruleset.css')
         binder.resources.append(resource)
 
-        collated_binder = self.target(binder)
+        collated_binder = self.target(binder, ruleset_bytes)
 
         # Check for the appended composite document
         self.assertEqual(len(collated_binder), 3)


### PR DESCRIPTION
Pass in recipe for baking - allow business logic above here to determine what recipe to bake with. Currently needed for fallback baking.  Also useful to create special purpose binders, using alternate recipes, without hardcoding recipe names.