### PR TITLE
metadata logic - license and language

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -539,6 +539,7 @@ HTML_DOCUMENT = """\
       xmlns:mod="http://cnx.rice.edu/#moduleIds"
       xmlns:md="http://cnx.rice.edu/mdml"
       xmlns:c="http://cnx.rice.edu/cnxml"
+      lang="{{ metadata['language'] }}"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta content="None" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta content="None" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
+++ b/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head>
     <title>Book One</title>

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -1,4 +1,5 @@
 <html
+  lang='en'
   xmlns='http://www.w3.org/1999/xhtml'
 >
   <head
@@ -7,7 +8,7 @@
   >
     <title>Desserts</title>
     <meta
-      content=''
+      content='en'
       data-type='language'
       itemprop='inLanguage'
     ></meta>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -1,4 +1,5 @@
 <html
+  lang='en'
   xmlns='http://www.w3.org/1999/xhtml'
   xmlns:m='http://www.w3.org/1998/Math/MathML'
 >
@@ -8,7 +9,7 @@
   >
     <title>Desserts</title>
     <meta
-      content=''
+      content='en'
       data-type='language'
       itemprop='inLanguage'
     ></meta>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/desserts-single-page.html
+++ b/cnxepub/tests/data/desserts-single-page.html
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage">
+    <meta content="en" data-type="language" itemprop="inLanguage">
 
     
     <meta content="MathML" itemprop="accessibilityFeature">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -1,8 +1,8 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="" data-type="language" itemprop="inLanguage"/>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
 
     
     <meta content="MathML" itemprop="accessibilityFeature"/>

--- a/cnxepub/tests/data/loose-pages/content/faux.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/faux.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head>
     <title>Loose Pages</title>

--- a/cnxepub/tests/data/loose-pages/content/fig-bush.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/fig-bush.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/data/loose-pages/content/mushroom-cloud.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/mushroom-cloud.xhtml
@@ -4,6 +4,7 @@
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:lrmi="http://lrmi.net/the-specification"
+      lang="en"
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -191,7 +191,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'derived_from_title': u'Wild Grains and Warted Feet',
             u'cnx-archive-uri': None,
             u'cnx-archive-shortid': None,
-            u'language': None,
+            u'language': 'en',
             u'print_style': u'* print style *',
             }
         self.assertEqual(expected_metadata, document.metadata)
@@ -673,7 +673,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
         # 'version': 'draft',
-        u'language': None,
+        u'language': 'en',
         u'print_style': None,
         u'cnx-archive-uri': None,
         u'cnx-archive-shortid': None,

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -106,7 +106,7 @@ class ReconstituteTestCase(unittest.TestCase):
             u'license_text': u'CC-By 4.0',
             u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
             # 'version': 'draft',
-            u'language': None,
+            u'language': 'en',
             u'print_style': None,
             u'cnx-archive-uri': None,
             u'cnx-archive-shortid': None,

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -325,6 +325,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
             'license_url': 'http://creativecommons.org/licenses/by/4.0/',
             'summary': "<p>summary</p>",
             'version': 'draft',
+            'language': 'en'
             }
 
         # Build test document.
@@ -400,6 +401,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
         'license_url': 'http://creativecommons.org/licenses/by/4.0/',
         'summary': "<p>summary</p>",
         'version': 'draft',
+        'language': 'en'
         }
 
     maxDiff = None
@@ -480,6 +482,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
             'title': self.base_metadata['title'],
             'license_url': self.base_metadata['license_url'],
             'license_text': self.base_metadata['license_text'],
+            'language': self.base_metadata['language']
             })
 
         metadata = self.base_metadata.copy()
@@ -708,7 +711,8 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             metadata={'title': 'Desserts',
                       'license_url': 'http://creativecommons.org/licenses/by/4.0/',
                       'license_text': 'CC-By 4.0',
-                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000'},
+                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000',
+                      'language': 'en'},
             resources=[cover_png])
 
     def test_binder(self):

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -61,6 +61,6 @@ class HTMLParsingTestCase(unittest.TestCase):
             'derived_from_uri': 'http://example.org/contents/id@ver',
             'derived_from_title': 'Wild Grains and Warted Feet',
             'print_style': '* print style *',
-            'language': None,
+            'language': 'en',
             }
         self.assertEqual(metadata, expected_metadata)


### PR DESCRIPTION
remove some unnecessary namespaces in xpaths used for metadata extraction.  Modified logic for metadata parsing for license* and language - use the `ancestor-or-self` axis in order to inherit certain metadata from parent nodes.