### PR TITLE
Remove extra xmlns:bib in sanitize xml XML_WRAPPER

### DIFF
--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -52,7 +52,6 @@ ATTRIBUTED_ROLE_KEYS = (
 XML_WRAPPER = """\
 <div
   xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:bib="http://bibtexml.sf.net/"
   xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute"
   xmlns:epub="http://www.idpf.org/2007/ops"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -83,9 +82,9 @@ def utf8(item):
         return item
 
 
-def _sanitize_xml(raw_xml):
+def _sanitize_xml(raw_xml, recover=True):
     """Wraps the XML and sanitizes the namespaces."""
-    xml_parser = etree.XMLParser(ns_clean=True, recover=True)
+    xml_parser = etree.XMLParser(ns_clean=True, recover=recover)
     elms = lxml.html.fragments_fromstring(raw_xml)
     # If the raw_xml starts with untagged content, it will be parsed
     # to a string rather than an Element instance.

--- a/cnxepub/tests/test_models.py
+++ b/cnxepub/tests/test_models.py
@@ -129,6 +129,11 @@ class PrivateUtilitiesTestCase(unittest.TestCase):
         xml = target(content)
         self.assertEqual(xml, 'aaa bbb')
 
+        # Sanitize content with recover=False
+        content = '<img src="aaa_bbb.png"/>'
+        xml = target(content, recover=False)
+        self.assertEqual(xml, '<img src="aaa_bbb.png"/>')
+
 
 class TreeUtilityTestCase(BaseModelTestCase):
 


### PR DESCRIPTION
We have parser recover=True which means we have hidden some xml errors when
parsing the xml in _sanitize_xml.  This was meant for the input xml but this
hid the error that we have in our code:

```
cnxepub/models.py:96: in _sanitize_xml
    xml = etree.fromstring(XML_WRAPPER.format(raw_xml), xml_parser)
src/lxml/lxml.etree.pyx:3228: in lxml.etree.fromstring (src/lxml/lxml.etree.c:79609)
src/lxml/parser.pxi:1848: in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:119128)
src/lxml/parser.pxi:1736: in lxml.etree._parseDoc (src/lxml/lxml.etree.c:117808)
src/lxml/parser.pxi:1102: in lxml.etree._BaseParser._parseDoc (src/lxml/lxml.etree.c:112052)
src/lxml/parser.pxi:595: in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:105896)
src/lxml/parser.pxi:706: in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:107604)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

E   XMLSyntaxError: Attribute xmlns:bib redefined, line 13, column 38 (line 13)

src/lxml/parser.pxi:635: XMLSyntaxError
```