### PR TITLE
make composite objects track top version, not parent

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -356,12 +356,13 @@ def adapt_single_html(html):
     nav_tree = parse_navigation_html_to_tree(html_root, id_)
 
     body = html_root.xpath('//xhtml:body', namespaces=HTML_DOCUMENT_NAMESPACES)
-    _adapt_single_html_tree(binder, body[0], nav_tree)
+    _adapt_single_html_tree(binder, body[0], nav_tree, top_metadata=metadata)
 
     return binder
 
 
-def _adapt_single_html_tree(parent, elem, nav_tree, id_map=None, depth=0):
+def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
+                            id_map=None, depth=0):
     title_overrides = [i.get('title') for i in nav_tree['contents']]
 
     # A dictionary to allow look up of a document and new id using the old html
@@ -480,8 +481,12 @@ def _adapt_single_html_tree(parent, elem, nav_tree, id_map=None, depth=0):
                 metadata['cnx-archive-shortid'] = \
                         _compute_shortid(metadata['cnx-archive-uri'])
 
-            if not metadata.get('version') and parent.metadata.get('version'):
-                metadata['version'] = parent.metadata.get('version')
+            if not metadata.get('version'):
+                if data_type.startswith('composite_'):
+                    if top_metadata.get('version') is not None:
+                        metadata['version'] = top_metadata.get('verison')
+                elif parent.metadata.get('version') is not None:
+                    metadata['version'] = parent.metadata.get('version')
 
             shortid = metadata.get('cnx-archive-shortid')
 
@@ -499,6 +504,7 @@ def _adapt_single_html_tree(parent, elem, nav_tree, id_map=None, depth=0):
             # Recurse
             _adapt_single_html_tree(binder, child,
                                     nav_tree['contents'].pop(0),
+                                    top_metadata=top_metadata,
                                     id_map=id_map, depth=depth+1)
             parent.append(binder)
         elif data_type in ['page', 'composite-page']:

--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -482,7 +482,7 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                         _compute_shortid(metadata['cnx-archive-uri'])
 
             if not metadata.get('version'):
-                if data_type.startswith('composite_'):
+                if data_type.startswith('composite-'):
                     if top_metadata.get('version') is not None:
                         metadata['version'] = top_metadata.get('verison')
                 elif parent.metadata.get('version') is not None:

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -107,7 +107,7 @@ class DocumentMetadataParser:
         'license_text', 'editors', 'illustrators', 'translators',
         'publishers', 'copyright_holders', 'authors', 'summary',
         'cnx-archive-uri', 'cnx-archive-shortid', 'derived_from_uri',
-        'derived_from_title', 'print_style',
+        'derived_from_title', 'print_style', 'version',
         )
 
     def __init__(self, elm_tree, raise_value_error=True):
@@ -304,6 +304,14 @@ class DocumentMetadataParser:
             './/xhtml:*[@data-type="cnx-archive-shortid"]/@data-value')
         if items:
             return items[0]
+
+    @property
+    def version(self):
+        items = self.parse(
+            './/xhtml:*[@data-type="cnx-archive-uri"]/@data-value')
+        if items:
+            if '@' in items[0]:
+                return items[0].split('@')[1]
 
     @property
     def derived_from_uri(self):

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -54,7 +54,7 @@
       >Desserts</h1>
       <span
         data-type='cnx-archive-uri'
-        data-value='00000000-0000-0000-0000-000000000000'
+        data-value='00000000-0000-0000-0000-000000000000@1.3'
       ></span>
       <div
         class='permissions'

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -55,7 +55,7 @@
       >Desserts</h1>
       <span
         data-type='cnx-archive-uri'
-        data-value='00000000-0000-0000-0000-000000000000'
+        data-value='00000000-0000-0000-0000-000000000000@1.3'
       ></span>
       <div
         class='permissions'

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -18,7 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
-      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">
         <p class="license">

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -18,7 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
-      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">
         <p class="license">

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -18,7 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
-      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">
         <p class="license">

--- a/cnxepub/tests/data/desserts-single-page.html
+++ b/cnxepub/tests/data/desserts-single-page.html
@@ -18,7 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
-      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"></span>
 
       <div class="permissions">
         <p class="license">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -18,7 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
-      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">
         <p class="license">

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -193,6 +193,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'cnx-archive-shortid': None,
             u'language': 'en',
             u'print_style': u'* print style *',
+            u'version': None,
             }
         self.assertEqual(expected_metadata, document.metadata)
 
@@ -672,13 +673,13 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         u'title': u'チョコレート',
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
-        # 'version': 'draft',
         u'language': 'en',
         u'print_style': None,
         u'cnx-archive-uri': None,
         u'cnx-archive-shortid': None,
         u'derived_from_title': None,
         u'derived_from_uri': None,
+        u'version': None,
         }
 
     def test_to_binder(self):
@@ -693,30 +694,30 @@ class HTMLAdaptationTestCase(unittest.TestCase):
 
         self.assertEqual({
             'shortId': None,
-            'id': '00000000-0000-0000-0000-000000000000',
+            'id': '00000000-0000-0000-0000-000000000000@1.3',
             'contents': [
                 {
                     'shortId': 'frt',
-                    'id': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2',
+                    'id': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3',
                     'contents': [
                         {
                             'shortId': None,
-                            'id': 'apple',
+                            'id': 'apple@1.3',
                             'title': 'Apple'
                         },
                         {
                             'shortId': None,
-                            'id': 'lemon',
+                            'id': 'lemon@1.3',
                             'title': '<span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span>'
                         },
 
                         {
-                            "shortId": "sfE7YYyV",
-                            "id": "b1f13b61-8c95-5fbe-9112-46400b6dc8de",
+                            'shortId': 'sfE7YYyV',
+                            'id': 'b1f13b61-8c95-5fbe-9112-46400b6dc8de@1.3',
                             'contents': [
                                 {
                                     'shortId': None,
-                                    'id': 'lemon',
+                                    'id': 'lemon@1.3',
                                     'title': 'Lemon'
                                 }
                             ],
@@ -727,7 +728,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
                 },
                 {
                     'shortId': None,
-                    'id': 'chocolate',
+                    'id': 'chocolate@1.3',
                     'title': u'\u30c1\u30e7\u30b3\u30ec\u30fc\u30c8'
                 },
                 {
@@ -750,6 +751,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('Document', apple.__class__.__name__)
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Apple'
+        metadata['version'] = '1.3'
         apple_metadata = apple.metadata.copy()
         summary = etree.fromstring(apple_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -765,6 +767,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('Document', lemon.__class__.__name__)
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Lemon'
+        metadata['version'] = '1.3'
         lemon_metadata = lemon.metadata.copy()
         summary = etree.fromstring(lemon_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -793,6 +796,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('summary', summary.text)
         metadata = self.base_metadata.copy()
         metadata['title'] = u'チョコレート'
+        metadata['version'] = '1.3'
         self.assertEqual(metadata, chocolate_metadata)
         self.assertIn('<p id="12302"><a href="#list">List</a> of',
                       chocolate.content)

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -47,26 +47,26 @@ class ReconstituteTestCase(unittest.TestCase):
 
         self.assertEqual({
             'shortId': None,
-            'id': '00000000-0000-0000-0000-000000000000',
+            'id': '00000000-0000-0000-0000-000000000000@1.3',
             'contents': [{
                 'shortId': 'frt',
-                'id': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2',
+                'id': 'ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3',
                 'contents': [{
                     'shortId': None,
-                    'id': 'apple',
+                    'id': 'apple@1.3',
                     'title': 'Apple'
                     },
                     {
                     'shortId': None,
-                    'id': 'lemon',
+                    'id': 'lemon@1.3',
                     'title': '<span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span>'
                     },
                     {
                     'shortId': 'sfE7YYyV',
-                    'id': 'b1f13b61-8c95-5fbe-9112-46400b6dc8de',
+                    'id': 'b1f13b61-8c95-5fbe-9112-46400b6dc8de@1.3',
                     'contents': [{
                         'shortId': None,
-                        'id': 'lemon',
+                        'id': 'lemon@1.3',
                         'title': 'Lemon'
                         }
                         ],
@@ -77,7 +77,7 @@ class ReconstituteTestCase(unittest.TestCase):
                     },
                     {
                         'shortId': None,
-                        'id': 'chocolate',
+                        'id': 'chocolate@1.3',
                         'title': u'\u30c1\u30e7\u30b3\u30ec\u30fc\u30c8'
                     },
                     {
@@ -112,6 +112,7 @@ class ReconstituteTestCase(unittest.TestCase):
             u'cnx-archive-shortid': None,
             u'derived_from_title': None,
             u'derived_from_uri': None,
+            u'version': None,
             }
 
         fruity = desserts[0]
@@ -122,6 +123,7 @@ class ReconstituteTestCase(unittest.TestCase):
         self.assertEqual('Document', apple.__class__.__name__)
         metadata = base_metadata.copy()
         metadata['title'] = 'Apple'
+        metadata['version'] = '1.3'
         apple_metadata = apple.metadata.copy()
         summary = etree.fromstring(apple_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -132,6 +134,8 @@ class ReconstituteTestCase(unittest.TestCase):
         self.assertEqual('Document', lemon.__class__.__name__)
         metadata = base_metadata.copy()
         metadata['title'] = 'Lemon'
+        metadata['version'] = '1.3'
+        apple_metadata = apple.metadata.copy()
         lemon_metadata = lemon.metadata.copy()
         summary = etree.fromstring(lemon_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -152,6 +156,8 @@ class ReconstituteTestCase(unittest.TestCase):
         self.assertEqual('summary', summary.text)
         metadata = base_metadata.copy()
         metadata['title'] = u'チョコレート'
+        metadata['version'] = '1.3'
+        apple_metadata = apple.metadata.copy()
         self.assertEqual(metadata, chocolate_metadata)
 
         extra = desserts[2]

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -711,7 +711,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             metadata={'title': 'Desserts',
                       'license_url': 'http://creativecommons.org/licenses/by/4.0/',
                       'license_text': 'CC-By 4.0',
-                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000',
+                      'cnx-archive-uri': '00000000-0000-0000-0000-000000000000@1.3',
                       'language': 'en'},
             resources=[cover_png])
 

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -62,5 +62,6 @@ class HTMLParsingTestCase(unittest.TestCase):
             'derived_from_title': 'Wild Grains and Warted Feet',
             'print_style': '* print style *',
             'language': 'en',
+            'version': '3',
             }
         self.assertEqual(metadata, expected_metadata)


### PR DESCRIPTION
The content of any given Composite Page or Binder can change with changes to any part of the book as a whole, not just direct ancestors. Explicitly track that info.