### PR TITLE
Set full metadata element to display none

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -576,7 +576,7 @@ HTML_DOCUMENT = """\
         {{ attr }}="{{ value }}"
       {%- endfor %}
         >
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">{{ \
               metadata['title'] }}</h1>
       {% if is_translucent %}
@@ -785,7 +785,7 @@ HTML_DOCUMENT = """\
       {%- endfor %}
       {% if resources %}
 
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
           {% for resource in resources -%}
           <li><a href="{{ resource.id }}">{{ resource.filename }}</a></li>

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -16,7 +16,7 @@
     <meta content="2013/06/18 15:22:55 -0500" itemprop="dateModified"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
@@ -70,13 +70,13 @@
         </ul>
       
       </div><div data-type="subject" itemprop="about">Science and Mathematics</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
    <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
-  <div data-type="unit"><div data-type="metadata">
+  <div data-type="unit"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -86,7 +86,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Part One</h1><div data-type="chapter"><div data-type="metadata">
+   <h1 data-type="document-title">Part One</h1><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Chapter One</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -96,7 +96,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -155,7 +155,7 @@
    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_84744">If you finish the book, there will be cake.</p>
   
   
-  </div></div><div data-type="chapter"><div data-type="metadata">
+  </div></div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Chapter Two</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -165,7 +165,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -224,7 +224,7 @@
    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_25507">If you finish the book, there will be cake.</p>
   
   
-  </div></div></div><div data-type="unit"><div data-type="metadata">
+  </div></div></div><div data-type="unit"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Part Two</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -234,7 +234,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Part Two</h1><div data-type="chapter"><div data-type="metadata">
+   <h1 data-type="document-title">Part Two</h1><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Chapter Three</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -244,7 +244,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -16,7 +16,7 @@
     <meta content="2013/06/18 15:22:55 -0500" itemprop="dateModified"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
@@ -70,13 +70,13 @@
         </ul>
       
       </div><div data-type="subject" itemprop="about">Science and Mathematics</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
    <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
-  <div data-type="unit"><div data-type="metadata">
+  <div data-type="unit"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -86,7 +86,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Part One</h1><div data-type="chapter"><div data-type="metadata">
+   <h1 data-type="document-title">Part One</h1><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Chapter One</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -96,7 +96,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -155,7 +155,7 @@
    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_74606">If you finish the book, there will be cake.</p>
   
   
-  </div></div><div data-type="chapter"><div data-type="metadata">
+  </div></div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Chapter Two</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -165,7 +165,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
@@ -224,7 +224,7 @@
    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_33432">If you finish the book, there will be cake.</p>
   
   
-  </div></div></div><div data-type="unit"><div data-type="metadata">
+  </div></div></div><div data-type="unit"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Part Two</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -234,7 +234,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Part Two</h1><div data-type="chapter"><div data-type="metadata">
+   <h1 data-type="document-title">Part Two</h1><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Chapter Three</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
@@ -244,7 +244,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata">
+   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -47,6 +47,7 @@
   >
     <div
       data-type='metadata'
+      style='display: none;'
     >
       <h1
         data-type='document-title'
@@ -72,7 +73,6 @@
       </div>
       <div
         data-type='resources'
-        style='display: none'
       >
         <ul>
           <li>
@@ -151,6 +151,7 @@
     >
       <div
         data-type='metadata'
+        style='display: none;'
       >
         <h1
           data-type='document-title'
@@ -188,6 +189,7 @@
       >
         <div
           data-type='metadata'
+          style='display: none;'
         >
           <h1
             data-type='document-title'
@@ -283,6 +285,7 @@
       >
         <div
           data-type='metadata'
+          style='display: none;'
         >
           <h1
             data-type='document-title'
@@ -352,7 +355,6 @@
           >Humanities</div>
           <div
             data-type='resources'
-            style='display: none'
           >
             <ul>
               <li>
@@ -410,6 +412,7 @@
       >
         <div
           data-type='metadata'
+          style='display: none;'
         >
           <h1
             data-type='document-title'
@@ -492,6 +495,7 @@
         >
           <div
             data-type='metadata'
+            style='display: none;'
           >
             <h1
               data-type='document-title'
@@ -561,7 +565,6 @@
             >Humanities</div>
             <div
               data-type='resources'
-              style='display: none'
             >
               <ul>
                 <li>
@@ -622,6 +625,7 @@
     >
       <div
         data-type='metadata'
+        style='display: none;'
       >
         <h1
           data-type='document-title'
@@ -691,7 +695,6 @@
         >Humanities</div>
         <div
           data-type='resources'
-          style='display: none'
         >
           <ul>
             <li>
@@ -735,6 +738,7 @@
     >
       <div
         data-type='metadata'
+        style='display: none;'
       >
         <h1
           data-type='document-title'

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -48,6 +48,7 @@
   >
     <div
       data-type='metadata'
+      style='display: none;'
     >
       <h1
         data-type='document-title'
@@ -73,7 +74,6 @@
       </div>
       <div
         data-type='resources'
-        style='display: none'
       >
         <ul>
           <li>
@@ -152,6 +152,7 @@
     >
       <div
         data-type='metadata'
+        style='display: none;'
       >
         <h1
           data-type='document-title'
@@ -189,6 +190,7 @@
       >
         <div
           data-type='metadata'
+          style='display: none;'
         >
           <h1
             data-type='document-title'
@@ -284,6 +286,7 @@
       >
         <div
           data-type='metadata'
+          style='display: none;'
         >
           <h1
             data-type='document-title'
@@ -353,7 +356,6 @@
           >Humanities</div>
           <div
             data-type='resources'
-            style='display: none'
           >
             <ul>
               <li>
@@ -450,6 +452,7 @@
       >
         <div
           data-type='metadata'
+          style='display: none;'
         >
           <h1
             data-type='document-title'
@@ -532,6 +535,7 @@
         >
           <div
             data-type='metadata'
+            style='display: none;'
           >
             <h1
               data-type='document-title'
@@ -601,7 +605,6 @@
             >Humanities</div>
             <div
               data-type='resources'
-              style='display: none'
             >
               <ul>
                 <li>
@@ -701,6 +704,7 @@
     >
       <div
         data-type='metadata'
+        style='display: none;'
       >
         <h1
           data-type='document-title'
@@ -770,7 +774,6 @@
         >Humanities</div>
         <div
           data-type='resources'
-          style='display: none'
         >
           <ul>
             <li>
@@ -814,6 +817,7 @@
     >
       <div
         data-type='metadata'
+        style='display: none;'
       >
         <h1
           data-type='document-title'

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -16,7 +16,7 @@
     <meta content="" itemprop="dateModified"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
@@ -26,13 +26,13 @@
           <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
         </p>
       </div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
    <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
-  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
       <span data-type="cnx-archive-shortid" data-value="frt"/>
@@ -43,7 +43,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
+   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
 
       <div class="authors">
@@ -78,7 +78,7 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -102,7 +102,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
@@ -147,7 +147,7 @@
 </ul>
 
 
-  </div><div data-type="chapter"><div data-type="metadata">
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
@@ -172,7 +172,7 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -196,7 +196,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
@@ -241,7 +241,7 @@
 </ul>
 
 
-  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata">
+  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
 
       <div class="authors">
@@ -265,7 +265,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
@@ -279,7 +279,7 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
-  </div><div data-type="composite-page" id="extra"><div data-type="metadata">
+  </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
       <div class="authors">

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -16,7 +16,7 @@
     <meta content="" itemprop="dateModified"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
@@ -26,13 +26,13 @@
           <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
         </p>
       </div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
    <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
-  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
       <span data-type="cnx-archive-shortid" data-value="frt"/>
@@ -43,7 +43,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
+   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
 
       <div class="authors">
@@ -78,7 +78,7 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -102,7 +102,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
@@ -134,7 +134,7 @@
 </ul>
 
 
-  </div><div data-type="chapter"><div data-type="metadata">
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
@@ -159,7 +159,7 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -183,7 +183,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
@@ -215,7 +215,7 @@
 </ul>
 
 
-  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata">
+  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
 
       <div class="authors">
@@ -239,7 +239,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
@@ -253,7 +253,7 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
-  </div><div data-type="composite-page" id="extra"><div data-type="metadata">
+  </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
       <div class="authors">

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -16,7 +16,7 @@
     <meta content="" itemprop="dateModified"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
@@ -26,13 +26,13 @@
           <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
    <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
-  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
       <span data-type="cnx-archive-shortid" data-value="frt"/>
@@ -43,7 +43,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
+   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
 
       <div class="authors">
@@ -78,7 +78,7 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -102,7 +102,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
@@ -131,7 +131,7 @@
 </ul>
 
 
-  </div><div data-type="chapter"><div data-type="metadata">
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
@@ -156,7 +156,7 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -180,7 +180,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
@@ -209,7 +209,7 @@
 </ul>
 
 
-  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata">
+  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
 
       <div class="authors">
@@ -233,7 +233,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
@@ -247,7 +247,7 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_210" src="/resources/1x1.jpg"/><p id="auto_chocolate_44539">チョコレートデザート</p>
-  </div><div data-type="composite-page" id="extra"><div data-type="metadata">
+  </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
       <div class="authors">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -16,7 +16,7 @@
     <meta content="" itemprop="dateModified"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
-    <div data-type="metadata">
+    <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"/>
 
@@ -26,13 +26,13 @@
           <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
         </p>
       </div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
    <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
-  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
+  <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
       <span data-type="cnx-archive-shortid" data-value="frt"/>
@@ -43,7 +43,7 @@
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
+   <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
 
       <div class="authors">
@@ -78,7 +78,7 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -102,7 +102,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
@@ -131,7 +131,7 @@
 </ul>
 
 
-  </div><div data-type="chapter"><div data-type="metadata">
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
@@ -156,7 +156,7 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
+   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
@@ -180,7 +180,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
@@ -209,7 +209,7 @@
 </ul>
 
 
-  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata">
+  </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
 
       <div class="authors">
@@ -233,7 +233,7 @@
       <div class="description" data-type="description" itemprop="description">
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
-      <div data-type="resources" style="display: none">
+      <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
@@ -247,7 +247,7 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
-  </div><div data-type="composite-page" id="extra"><div data-type="metadata">
+  </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
       <div class="authors">


### PR DESCRIPTION
Making all of the metadata `display: none` for single_html instead of just a portion. Making this change in cnx-epub as per conversation in https://github.com/Connexions/cnx-recipes/pull/416.