### PR TITLE
Content truncation fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@
 
    - feature message
 
+0.14.0
+------
+
+- fix issue with truncation of pages when parsing (#131)
+
 0.13.0
 ------
 

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -56,7 +56,7 @@ class DocumentContentFormatter(object):
         html = """\
 <html xmlns="http://www.w3.org/1999/xhtml">
   <body>{}</body>
-</html>""".format(self.document.content)
+</html>""".format(utf8(self.document.content))
         return html.encode('utf-8')
 
 

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -68,7 +68,8 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Apple Desserts</h1>
+   
+<h1>Apple Desserts</h1>
 
 <p id="auto_apple_74606"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
 
@@ -78,6 +79,8 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
+
+
   </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -270,7 +273,8 @@
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
 
-   <h1>Chocolate Desserts</h1>
+   
+<h1>Chocolate Desserts</h1>
 
 <p id="auto_chocolate_12302"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
 
@@ -279,6 +283,8 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+
+
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
@@ -304,10 +310,13 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Extra Stuff</h1>
+   
+<h1>Extra Stuff</h1>
 
 <p id="auto_extra_51093">This is a composite page.</p>
 
 <p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
+
+
   </div></body>
 </html>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -68,7 +68,8 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Apple Desserts</h1>
+   
+<h1>Apple Desserts</h1>
 
 <p id="auto_apple_74606"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
 
@@ -78,6 +79,8 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
+
+
   </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -244,7 +247,8 @@
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
       </div>    </div>
 
-   <h1>Chocolate Desserts</h1>
+   
+<h1>Chocolate Desserts</h1>
 
 <p id="auto_chocolate_12302"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
 
@@ -253,6 +257,8 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+
+
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
@@ -278,10 +284,13 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Extra Stuff</h1>
+   
+<h1>Extra Stuff</h1>
 
 <p id="auto_extra_51093">This is a composite page.</p>
 
 <p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
+
+
   </div></body>
 </html>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -68,7 +68,8 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Apple Desserts</h1>
+   
+<h1>Apple Desserts</h1>
 
 <p id="auto_apple_84744"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
@@ -78,6 +79,8 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
+
+
   </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -238,7 +241,8 @@
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
 
-   <h1>Chocolate Desserts</h1>
+   
+<h1>Chocolate Desserts</h1>
 
 <p id="auto_chocolate_76228"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
 
@@ -247,6 +251,8 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_210" src="/resources/1x1.jpg"/><p id="auto_chocolate_44539">チョコレートデザート</p>
+
+
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
@@ -272,10 +278,13 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Extra Stuff</h1>
+   
+<h1>Extra Stuff</h1>
 
 <p id="auto_extra_72154">This is a composite page.</p>
 
 <p id="auto_extra_22876">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+
+
   </div></body>
 </html>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -68,7 +68,8 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Apple Desserts</h1>
+   
+<h1>Apple Desserts</h1>
 
 <p id="auto_apple_74606"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
@@ -78,6 +79,8 @@
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
+
+
   </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
@@ -238,7 +241,8 @@
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
       </div>    </div>
 
-   <h1>Chocolate Desserts</h1>
+   
+<h1>Chocolate Desserts</h1>
 
 <p id="auto_chocolate_12302"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
 
@@ -247,6 +251,8 @@
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+
+
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 
@@ -272,10 +278,13 @@
         <p>summary</p>
       </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
 
-   <h1>Extra Stuff</h1>
+   
+<h1>Extra Stuff</h1>
 
 <p id="auto_extra_51093">This is a composite page.</p>
 
 <p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+
+
   </div></body>
 </html>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -757,9 +757,9 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, apple_metadata)
-        self.assertIn('<p id="74606">'
-                      '<a href="/contents/lemon">Link to lemon</a>. '
-                      'Here are some examples:</p>',
+        self.assertIn(b'<p id="74606">'
+                      b'<a href="/contents/lemon">Link to lemon</a>. '
+                      b'Here are some examples:</p>',
                       apple.content)
         self.assertEqual('Apple', fruity.get_title_for_node(apple))
 
@@ -773,8 +773,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, lemon_metadata)
-        self.assertIn('<p id="8271">Yum! <img id="33432" '
-                      'src="/resources/1x1.jpg"/></p>', lemon.content)
+        self.assertIn(b'<p id="8271">Yum! <img id="33432" '
+                      b'src="/resources/1x1.jpg"/></p>', lemon.content)
         self.assertEqual('<span>1.1</span> <span>|</span> <span>'
                          '&#12524;&#12514;&#12531;</span>',
                          fruity.get_title_for_node(lemon))
@@ -798,9 +798,9 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         metadata['title'] = u'チョコレート'
         metadata['version'] = '1.3'
         self.assertEqual(metadata, chocolate_metadata)
-        self.assertIn('<p id="12302"><a href="#list">List</a> of',
+        self.assertIn(b'<p id="12302"><a href="#list">List</a> of',
                       chocolate.content)
-        self.assertIn('<div data-type="list" id="list"><ul>',
+        self.assertIn(b'<div data-type="list" id="list"><ul>',
                       chocolate.content)
         self.assertEqual(u'チョコレート',
                          desserts.get_title_for_node(chocolate))
@@ -815,8 +815,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         metadata['title'] = 'Extra Stuff'
         metadata['version'] = '1.3'
         self.assertEqual(metadata, extra_metadata)
-        self.assertIn('<p id="56723">Here is a <a href="/contents/chocolate'
-                      '#list">link</a> to another document.</p>',
+        self.assertIn(b'<p id="56723">Here is a <a href="/contents/chocolate'
+                      b'#list">link</a> to another document.</p>',
                       extra.content)
         self.assertEqual('Extra Stuff', desserts.get_title_for_node(extra))
 
@@ -860,15 +860,15 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         chocolate = desserts[1]
         extra = desserts[2]
 
-        self.assertIn('<p id="1">Content moved from another page.</p>',
+        self.assertIn(b'<p id="1">Content moved from another page.</p>',
                       extra.content)
-        self.assertIn('Click <a href="/contents/9f7dce40-0de7-5a29-a416-a9cf8eedf4d4#1">here</a>',
+        self.assertIn(b'Click <a href="/contents/9f7dce40-0de7-5a29-a416-a9cf8eedf4d4#1">here</a>',
                       chocolate.content)
-        self.assertIn('<p id="summary0"> Pretend move of lemon summary</p>',
+        self.assertIn(b'<p id="summary0"> Pretend move of lemon summary</p>',
                       extra.content)
-        self.assertIn('<p id="summary1"> Pretend move of chocolate summary</p>',
+        self.assertIn(b'<p id="summary1"> Pretend move of chocolate summary</p>',
                       extra.content)
-        self.assertIn('<p id="myid">Be sure to read the <a href="/contents/9f7dce40-0de7-5a29-a416-a9cf8eedf4d4#summary0">Summary for lemon</a></p>', lemon.content)
+        self.assertIn(b'<p id="myid">Be sure to read the <a href="/contents/9f7dce40-0de7-5a29-a416-a9cf8eedf4d4#summary0">Summary for lemon</a></p>', lemon.content)
 
     def test_fix_generated_ids_links_without_version(self):
         from ..adapters import adapt_single_html
@@ -881,5 +881,5 @@ class HTMLAdaptationTestCase(unittest.TestCase):
 
         desserts = adapt_single_html(html)
         apple = desserts[0][0]
-        self.assertIn('<p id="12345"><a href="/contents/chocolate">',
+        self.assertIn(b'<p id="12345"><a href="/contents/chocolate">',
                       apple.content)

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -346,7 +346,7 @@ class DocumentSummaryFormatterTestCase(unittest.TestCase):
         from ..formatters import DocumentSummaryFormatter
         from ..models import Document
 
-        document = Document('title', io.BytesIO(b'contents'),
+        document = Document('title', io.BytesIO(b'<p>contents</p>'),
                             metadata={'summary': '<p>résumé</p>'})
         html = str(DocumentSummaryFormatter(document))
         self.assertEqual('<p>résumé</p>', html)
@@ -355,7 +355,7 @@ class DocumentSummaryFormatterTestCase(unittest.TestCase):
         from ..formatters import DocumentSummaryFormatter
         from ..models import Document
 
-        document = Document('title', io.BytesIO(b'contents'),
+        document = Document('title', io.BytesIO(b'<p>contents</p>'),
                             metadata={'summary': 'résumé'})
         html = str(DocumentSummaryFormatter(document))
         expected = """\
@@ -369,7 +369,7 @@ class DocumentSummaryFormatterTestCase(unittest.TestCase):
         from ..formatters import DocumentSummaryFormatter
         from ..models import Document
 
-        document = Document('title', io.BytesIO(b'contents'),
+        document = Document('title', io.BytesIO(b'<p>contents</p>'),
                             metadata={'summary': 'résumé<p>etc</p><p>...</p>'})
         html = str(DocumentSummaryFormatter(document))
         expected = """\
@@ -569,10 +569,10 @@ class HTMLFormatterTestCase(unittest.TestCase):
         from ..formatters import HTMLFormatter
 
         random.seed(1)
-        content = """\
+        content = """<div>\
 <div class="title" id="title">Preface</div>
 <p class="para" id="my-id">This thing and <em>that</em> thing.</p>
-<p class="para"><a href="#title">Link</a> to title</p>"""
+<p class="para"><a href="#title">Link</a> to title</p></div>"""
         page_one_id = 'fa21215a-91b5-424a-9fbd-5c451f309b87'
 
         expected_content = """\
@@ -624,6 +624,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
 
         metadata = self.base_metadata.copy()
         contents = io.BytesIO(u"""\
+<div>
 <h1>Chocolate Desserts</h1>
 <p><a href="#list">List</a> of desserts to try:</p>
 <div data-type="list" id="list"><ul><li>Chocolate Orange Tart,</li>
@@ -631,6 +632,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img src="/resources/1x1.jpg" /><p>チョコレートデザート</p>
+</div>
 """.encode('utf-8'))
         self.chocolate = Document('chocolate', contents, metadata=metadata,
                                   resources=[jpg])
@@ -638,6 +640,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Apple'
         contents = io.BytesIO(b"""\
+<div>
 <h1>Apple Desserts</h1>
 <p><a href="/contents/lemon">Link to lemon</a>. Here are some examples:</p>
 <ul><li id="auto_apple_13436">Apple Crumble,</li>
@@ -646,6 +649,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
+</div>
 """)
         self.apple = Document('apple', contents, metadata=metadata)
 
@@ -694,9 +698,11 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Extra Stuff'
         contents = io.BytesIO(b"""\
+<div>
 <h1>Extra Stuff</h1>
 <p>This is a composite page.</p>
 <p>Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+</div>
 """)
         self.extra = CompositeDocument(
             'extra', contents, metadata=metadata)

--- a/cnxepub/tests/test_models.py
+++ b/cnxepub/tests/test_models.py
@@ -342,7 +342,7 @@ class ModelBehaviorTestCase(unittest.TestCase):
         document.content = content
         # update some references
         document.references[0].uri = 'https://example.com/people/old-mcdonald'
-        self.assertTrue('<a href="https://example.com/people/old-mcdonald">'
+        self.assertTrue(b'<a href="https://example.com/people/old-mcdonald">'
                         in document.content)
 
     def test_document_w_bound_references(self):
@@ -397,5 +397,5 @@ class ModelBehaviorTestCase(unittest.TestCase):
             metadata = json.loads(f.read())
         from ..models import Document
         document = Document('document', metadata['content'])
-        self.assertTrue('To demonstrate the potential of online publishing'
+        self.assertTrue(b'To demonstrate the potential of online publishing'
                         in document.content)


### PR DESCRIPTION
adapting full-html after baking has been mysteriously truncating content with lxml 4.2.5. Fix by removing the support for non-valid-xml-tree documents.